### PR TITLE
Fix assignment of `max_requests_jitter` in config

### DIFF
--- a/src/anycorn/__main__.py
+++ b/src/anycorn/__main__.py
@@ -290,7 +290,7 @@ def main(
     if max_requests is not None:
         config.max_requests = max_requests
     if max_requests_jitter is not None:
-        config.max_requests_jitter = max_requests
+        config.max_requests_jitter = max_requests_jitter
     if pid is not None:
         config.pid_path = pid
     if root_path is not None:


### PR DESCRIPTION
Whilst looking at the code I noticed this bug. It's only minor and doesn't affect me (I don't use that setting) but I thought I'd put in a PR regardless.