### PR TITLE
Port hypercorn fix for shared connection state

### DIFF
--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote
 from anycorn.typing import (
     AppWrapper,
     ASGISendEvent,
+    ConnectionState,
     Extensions,
     HTTPResponseStartEvent,
     HTTPScope,
@@ -131,7 +132,7 @@ class HTTPStream:
                 headers=event.headers,
                 client=self.client,
                 server=self.server,
-                state=event.state,
+                state=ConnectionState(event.state.copy()),
                 extensions=extensions,
             )
 

--- a/src/anycorn/protocol/ws_stream.py
+++ b/src/anycorn/protocol/ws_stream.py
@@ -36,6 +36,9 @@ from anycorn.typing import (
     WebsocketScope,
     WorkerContext,
 )
+from anycorn.typing import (
+    ConnectionState as ASGIConnectionState,
+)
 from anycorn.utils import (
     UnexpectedMessageError,
     build_and_validate_headers,
@@ -263,7 +266,7 @@ class WSStream:
                 "headers": event.headers,
                 "client": self.client,
                 "server": self.server,
-                "state": event.state,
+                "state": ASGIConnectionState(event.state.copy()),
                 "subprotocols": self.handshake.subprotocols or [],
                 "extensions": extensions,
             }

--- a/src/anycorn/run.py
+++ b/src/anycorn/run.py
@@ -231,7 +231,7 @@ async def worker_serve(  # noqa: C901, PLR0915
                             partial(
                                 listener.serve,
                                 tcp_server_handler(
-                                    app, config, context, ConnectionState(lifespan_state.copy())
+                                    app, config, context, ConnectionState(lifespan_state)
                                 ),
                             ),
                         )

--- a/src/anycorn/tcp_server.py
+++ b/src/anycorn/tcp_server.py
@@ -69,7 +69,7 @@ class TCPServer:
                     self.config,
                     self.context,
                     task_group,
-                    ConnectionState(self.state.copy()),
+                    ConnectionState(self.state),
                     client,
                     server,
                     self.protocol_send,

--- a/src/anycorn/udp_server.py
+++ b/src/anycorn/udp_server.py
@@ -53,7 +53,7 @@ class UDPServer:
                 self.config,
                 self.context,
                 task_group,
-                ConnectionState(self.state.copy()),
+                ConnectionState(self.state),
                 server,
                 self.protocol_send,
             )

--- a/tests/e2e/test_httpx.py
+++ b/tests/e2e/test_httpx.py
@@ -32,6 +32,56 @@ async def app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
     )
 
 
+async def isolate_state_app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
+    assert scope["type"] == "http"
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain"]],
+        }
+    )
+    # Send back whatever the previous request may have left in state, and then
+    # mutate the state. Per ASGI spec each request should get its own state,
+    # so a second request on the same (keep-alive) connection shouldn't see this.
+    await send(
+        {
+            "type": "http.response.body",
+            "body": scope["state"].get("key", b""),
+            "more_body": False,
+        }
+    )
+    scope["state"]["key"] = b"one"
+
+
+@pytest.mark.anyio
+async def test_handle_isolate_state() -> None:
+    config = Config()
+    config.bind = ["127.0.0.1:1235"]
+    config.accesslog = "-"
+    config.errorlog = "-"
+
+    async with anyio.create_task_group() as tg:
+        shutdown = anyio.Event()
+
+        async def serve() -> None:
+            await anycorn.serve(isolate_state_app, config, shutdown_trigger=shutdown.wait)
+
+        tg.start_soon(serve)
+
+        await anyio.wait_all_tasks_blocked()
+
+        # A single client reuses one keep-alive connection for both requests.
+        async with httpx.AsyncClient() as client:
+            first = await client.get("http://127.0.0.1:1235/")
+            second = await client.get("http://127.0.0.1:1235/")
+
+        assert first.content == b""
+        assert second.content == b""
+
+        shutdown.set()
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize("anyio_backend", ["asyncio"])  # FIXME
 async def test_keep_alive_max_requests_regression() -> None:


### PR DESCRIPTION
This PR is a port for the shared `scope["state"]` that was fixed in [hypercorn #275](https://github.com/pgjones/hypercorn/pull/275/changes).

I moved the state dict copy from connection setup to per-request scope creation. Previously all requests on a shared connection received the same `ConnectionState` object, so writes to `scope["state"]` in one request leaked into others if the connection was reused. 

After this PR each request's scope gets its own state.copy().

**Changes**

- Ports the Hypercorn fix. 
- Adds an httpx e2e test verifying request state isolation.

**Background**

According the [ASGI Spec for http](https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope): 

> HTTP connections have a **single-request** connection scope - that is, your application will be called at the start of the request, and will last until the end of that specific request, *even if the underlying socket is still open and serving multiple requests*.

Fixes #37 