### PR TITLE
Close leaked sockets, streams and logger resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ h3 = [
 test = [
     "anycorn[h3]",
     "httpx",
-    "pytest",
+    "pytest>=9.1.1",
     "mock",
     "trio",
 ]
@@ -66,8 +66,9 @@ dev = [
 anycorn = "anycorn.__main__:main"
 
 [tool.pytest.ini_options]
-addopts = "--showlocals --strict-markers --color=yes -v"
+addopts = "-W error --showlocals --strict-markers --color=yes -v"
 testpaths = ["tests"]
+strict = true
 
 [tool.ruff]
 lint.extend-select = [# https://docs.astral.sh/ruff/settings/#extend-select

--- a/src/anycorn/logging.py
+++ b/src/anycorn/logging.py
@@ -13,13 +13,17 @@ from logging.config import dictConfig, fileConfig
 from typing import IO, TYPE_CHECKING, Any
 
 if sys.version_info >= (3, 11):
+    from typing import Self
+
     import tomllib
 else:
     import tomli as tomllib
+    from typing_extensions import Self
 
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from types import TracebackType
 
     from .config import Config
     from .typing import ResponseSummary, WWWScope
@@ -129,6 +133,20 @@ class Logger:
         """Log a message at the given numeric level."""
         if self.error_logger is not None:
             self.error_logger.log(level, message, *args, **kwargs)
+
+    async def aclose(self) -> None:
+        """Release any resources held by the logger."""
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.aclose()
 
     def atoms(
         self, request: WWWScope, response: ResponseSummary | None, request_time: float

--- a/src/anycorn/logging.py
+++ b/src/anycorn/logging.py
@@ -12,18 +12,16 @@ from http import HTTPStatus
 from logging.config import dictConfig, fileConfig
 from typing import IO, TYPE_CHECKING, Any
 
-if sys.version_info >= (3, 11):
-    from typing import Self
+from anyio.abc import AsyncResource
 
+if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib
-    from typing_extensions import Self
 
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from types import TracebackType
 
     from .config import Config
     from .typing import ResponseSummary, WWWScope
@@ -57,7 +55,7 @@ def _create_logger(
     return None
 
 
-class Logger:
+class Logger(AsyncResource):
     """Anycorn logger providing access and error logging."""
 
     def __init__(self, config: Config) -> None:
@@ -136,17 +134,6 @@ class Logger:
 
     async def aclose(self) -> None:
         """Release any resources held by the logger."""
-
-    async def __aenter__(self) -> Self:
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        tb: TracebackType | None,
-    ) -> None:
-        await self.aclose()
 
     def atoms(
         self, request: WWWScope, response: ResponseSummary | None, request_time: float

--- a/src/anycorn/middleware/dispatcher.py
+++ b/src/anycorn/middleware/dispatcher.py
@@ -17,6 +17,11 @@ if TYPE_CHECKING:
 MAX_QUEUE_SIZE = 10
 
 
+async def _call_app(app: ASGIFramework, scope: Scope, receive: Callable, send: Callable) -> None:
+    # An ASGI app returns an Awaitable, whilst start_soon requires a coroutine function
+    await app(scope, receive, send)
+
+
 class _DispatcherMiddleware:
     def __init__(self, mounts: dict[str, ASGIFramework]) -> None:
         self.mounts = mounts
@@ -68,6 +73,7 @@ class DispatcherMiddleware(_DispatcherMiddleware):
             tg = await stack.enter_async_context(anyio.create_task_group())
             for path, app in self.mounts.items():
                 tg.start_soon(
+                    _call_app,
                     app,
                     scope,
                     self.app_queues[path][1].receive,

--- a/src/anycorn/middleware/dispatcher.py
+++ b/src/anycorn/middleware/dispatcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import AsyncExitStack
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -59,7 +60,12 @@ class DispatcherMiddleware(_DispatcherMiddleware):
         self.startup_complete = dict.fromkeys(self.mounts, False)
         self.shutdown_complete = dict.fromkeys(self.mounts, False)
 
-        async with anyio.create_task_group() as tg:
+        async with AsyncExitStack() as stack:
+            for send_stream, receive_stream in self.app_queues.values():
+                await stack.enter_async_context(send_stream)
+                await stack.enter_async_context(receive_stream)
+
+            tg = await stack.enter_async_context(anyio.create_task_group())
             for path, app in self.mounts.items():
                 tg.start_soon(
                     app,

--- a/src/anycorn/run.py
+++ b/src/anycorn/run.py
@@ -6,6 +6,7 @@ import platform
 import signal
 import sys
 import time
+from contextlib import AsyncExitStack
 from functools import partial
 from multiprocessing import get_context
 from multiprocessing.connection import wait
@@ -180,11 +181,11 @@ async def worker_serve(  # noqa: C901, PLR0915
         max_requests = config.max_requests + randint(0, config.max_requests_jitter)  # noqa: S311
     context = WorkerContext(max_requests)
 
-    async with anyio.create_task_group() as lifespan_tg:
+    async with config.log, anyio.create_task_group() as lifespan_tg:
         await lifespan_tg.start(lifespan.handle_lifespan)
         await lifespan.wait_for_startup()
 
-        async with anyio.create_task_group() as server_tg:
+        async with anyio.create_task_group() as server_tg, AsyncExitStack() as listener_stack:
             if sockets is None:
                 sockets = config.create_sockets()
                 for sock in sockets.secure_sockets:
@@ -204,7 +205,7 @@ async def worker_serve(  # noqa: C901, PLR0915
                     True,  # noqa: FBT003
                     config.ssl_handshake_timeout,
                 )
-                listeners.append(secure_listener)
+                listeners.append(await listener_stack.enter_async_context(secure_listener))
                 bind = repr_socket_addr(secure_sock.family, secure_sock.getsockname())
                 url = f"https://{bind}"
                 binds.append(url)
@@ -213,7 +214,7 @@ async def worker_serve(  # noqa: C901, PLR0915
             for insecure_sock in sockets.insecure_sockets:
                 asynclib = anyio._core._eventloop.get_async_backend()  # noqa: SLF001  # ty:ignore[possibly-missing-attribute]
                 insecure_listener = asynclib.create_tcp_listener(insecure_sock)
-                listeners.append(insecure_listener)
+                listeners.append(await listener_stack.enter_async_context(insecure_listener))
                 bind = repr_socket_addr(insecure_sock.family, insecure_sock.getsockname())
                 url = f"http://{bind}"
                 binds.append(url)

--- a/src/anycorn/statsd.py
+++ b/src/anycorn/statsd.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import socket
+import sys
 from typing import TYPE_CHECKING, Any
 
 import anyio
 import anyio.abc
+import sniffio
 
 from .logging import Logger
 
@@ -117,26 +120,105 @@ class BaseStatsdLogger(Logger):
         raise NotImplementedError
 
 
+class _DatagramProtocol(asyncio.DatagramProtocol):
+    def __init__(self) -> None:
+        self.closed = asyncio.Event()
+        self.write_event = asyncio.Event()
+        self.write_event.set()
+
+    def pause_writing(self) -> None:
+        self.write_event.clear()
+
+    def resume_writing(self) -> None:
+        self.write_event.set()
+
+    def connection_lost(self, exc: Exception | None) -> None:  # noqa: ARG002
+        self.write_event.set()
+        self.closed.set()
+
+
+class _AsyncioSender:
+    """Sends datagrams via asyncio, so that the transport can be aborted on close.
+
+    Used only on Windows, where the proactor event loop will not schedule
+    `connection_lost()` from `transport.close()` whilst a write is in flight - leaving
+    the socket unclosed and anyio's `aclose()`, which waits for that event, hanging
+    forever. `abort()` carries no such condition, and anyio's UDP wrapper offers no way
+    to reach it. Every other platform uses `_AnyioSender`.
+    """
+
+    def __init__(self, transport: asyncio.DatagramTransport, protocol: _DatagramProtocol) -> None:
+        self._transport = transport
+        self._protocol = protocol
+
+    @classmethod
+    async def create(cls, host: str, port: int) -> _AsyncioSender:
+        transport, protocol = await asyncio.get_running_loop().create_datagram_endpoint(
+            _DatagramProtocol,
+            remote_addr=(host, port),
+            family=socket.AddressFamily.AF_INET,
+        )
+        return cls(transport, protocol)
+
+    async def send(self, message: bytes) -> None:
+        # Datagram transports have no drain, so this is the transport's high/low water
+        # mark flow control, matching what anyio's own send() waits on
+        await self._protocol.write_event.wait()
+        self._transport.sendto(message)
+
+    async def aclose(self) -> None:
+        self._transport.close()
+        try:
+            # Give a completing write the chance to close the transport by itself
+            await asyncio.sleep(0)
+        finally:
+            # Unlike close(), abort() always schedules connection_lost, so this must
+            # run even if the checkpoint above is cancelled
+            self._transport.abort()
+
+        await self._protocol.closed.wait()
+
+
+class _AnyioSender:
+    """Sends datagrams via anyio, for backends other than asyncio."""
+
+    def __init__(self, sock: anyio.abc.ConnectedUDPSocket) -> None:
+        self._socket = sock
+
+    @classmethod
+    async def create(cls, host: str, port: int) -> _AnyioSender:
+        return cls(
+            await anyio.create_connected_udp_socket(host, port, family=socket.AddressFamily.AF_INET)
+        )
+
+    async def send(self, message: bytes) -> None:
+        await self._socket.send(message)
+
+    async def aclose(self) -> None:
+        await self._socket.aclose()
+
+
 class StatsdLogger(BaseStatsdLogger):
     """StatsD logger that sends metrics over UDP."""
-
-    socket: anyio.abc.ConnectedUDPSocket | None
 
     def __init__(self, config: Config) -> None:
         super().__init__(config)
         assert config.statsd_host is not None
         self.address = tuple(config.statsd_host.rsplit(":", 1))
-        self.socket = None
+        self._sender: _AsyncioSender | _AnyioSender | None = None
 
     async def _socket_send(self, message: bytes) -> None:
-        if self.socket is None:
-            self.socket = await anyio.create_connected_udp_socket(
-                self.address[0], int(self.address[1]), family=socket.AddressFamily.AF_INET
-            )
-        await self.socket.send(message)
+        if self._sender is None:
+            host, port = self.address[0], int(self.address[1])
+            if sys.platform == "win32" and sniffio.current_async_library() == "asyncio":
+                self._sender = await _AsyncioSender.create(host, port)
+            else:
+                self._sender = await _AnyioSender.create(host, port)
+
+        await self._sender.send(message)
 
     async def aclose(self) -> None:
         """Close the UDP socket, if one has been opened."""
-        if self.socket is not None:
-            await self.socket.aclose()
-            self.socket = None
+        if self._sender is not None:
+            sender, self._sender = self._sender, None
+            await sender.aclose()

--- a/src/anycorn/statsd.py
+++ b/src/anycorn/statsd.py
@@ -146,6 +146,7 @@ class _AsyncioSender:
     the socket unclosed and anyio's `aclose()`, which waits for that event, hanging
     forever. `abort()` carries no such condition, and anyio's UDP wrapper offers no way
     to reach it. Every other platform uses `_AnyioSender`.
+    see https://github.com/agronholm/anyio/issues/1237
     """
 
     def __init__(self, transport: asyncio.DatagramTransport, protocol: _DatagramProtocol) -> None:

--- a/src/anycorn/statsd.py
+++ b/src/anycorn/statsd.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 import anyio
 import anyio.abc
-import anyio.lowlevel
 
 from .logging import Logger
 
@@ -139,11 +138,5 @@ class StatsdLogger(BaseStatsdLogger):
     async def aclose(self) -> None:
         """Close the UDP socket, if one has been opened."""
         if self.socket is not None:
-            sock, self.socket = self.socket, None
-            try:
-                await sock.aclose()
-            finally:
-                # anyio only asks the transport to close; on asyncio the socket itself is
-                # released by a callback scheduled for the next loop iteration, so yield to
-                # let that run rather than leave it pending when the loop is torn down.
-                await anyio.lowlevel.cancel_shielded_checkpoint()
+            await self.socket.aclose()
+            self.socket = None

--- a/src/anycorn/statsd.py
+++ b/src/anycorn/statsd.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 import anyio
 import anyio.abc
 import sniffio
+from anyio.abc import SocketAttribute
 
 from .logging import Logger
 
@@ -150,6 +151,7 @@ class _AsyncioSender:
     def __init__(self, transport: asyncio.DatagramTransport, protocol: _DatagramProtocol) -> None:
         self._transport = transport
         self._protocol = protocol
+        self.socket: socket.socket = transport.get_extra_info("socket")
 
     @classmethod
     async def create(cls, host: str, port: int) -> _AsyncioSender:
@@ -186,6 +188,7 @@ class _AnyioSender:
 
     def __init__(self, sock: anyio.abc.ConnectedUDPSocket) -> None:
         self._socket = sock
+        self.socket: socket.socket = sock.extra(SocketAttribute.raw_socket)  # noqa: S610
 
     @classmethod
     async def create(cls, host: str, port: int) -> _AnyioSender:

--- a/src/anycorn/statsd.py
+++ b/src/anycorn/statsd.py
@@ -173,10 +173,12 @@ class _AsyncioSender:
             await asyncio.sleep(0)
         finally:
             # Unlike close(), abort() always schedules connection_lost, so this must
-            # run even if the checkpoint above is cancelled
+            # run even if the checkpoint above is cancelled. Having scheduled it, the
+            # wait is bounded by a single iteration of the loop, so shield it: a
+            # cancelled close must still leave the socket released.
             self._transport.abort()
-
-        await self._protocol.closed.wait()
+            with anyio.CancelScope(shield=True):
+                await self._protocol.closed.wait()
 
 
 class _AnyioSender:

--- a/src/anycorn/statsd.py
+++ b/src/anycorn/statsd.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import anyio
 import anyio.abc
+import anyio.lowlevel
 
 from .logging import Logger
 
@@ -138,5 +139,11 @@ class StatsdLogger(BaseStatsdLogger):
     async def aclose(self) -> None:
         """Close the UDP socket, if one has been opened."""
         if self.socket is not None:
-            await self.socket.aclose()
-            self.socket = None
+            sock, self.socket = self.socket, None
+            try:
+                await sock.aclose()
+            finally:
+                # anyio only asks the transport to close; on asyncio the socket itself is
+                # released by a callback scheduled for the next loop iteration, so yield to
+                # let that run rather than leave it pending when the loop is torn down.
+                await anyio.lowlevel.cancel_shielded_checkpoint()

--- a/src/anycorn/statsd.py
+++ b/src/anycorn/statsd.py
@@ -134,3 +134,9 @@ class StatsdLogger(BaseStatsdLogger):
                 self.address[0], int(self.address[1]), family=socket.AddressFamily.AF_INET
             )
         await self.socket.send(message)
+
+    async def aclose(self) -> None:
+        """Close the UDP socket, if one has been opened."""
+        if self.socket is not None:
+            await self.socket.aclose()
+            self.socket = None

--- a/src/anycorn/task_group.py
+++ b/src/anycorn/task_group.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, cast
 
 import anyio
 import anyio.abc
 import anyio.from_thread
+import anyio.streams.memory
 import anyio.to_thread
 
 from .typing import AppWrapper, ASGIReceiveCallable, ASGIReceiveEvent, ASGISendEvent, Scope
@@ -29,13 +31,19 @@ async def _handle(  # noqa: PLR0913
     app: AppWrapper,
     config: Config,
     scope: Scope,
-    receive: ASGIReceiveCallable,
+    channels: tuple[
+        anyio.streams.memory.MemoryObjectSendStream[ASGIReceiveEvent],
+        anyio.streams.memory.MemoryObjectReceiveStream[ASGIReceiveEvent],
+    ],
     send: Callable[[ASGISendEvent | None], Awaitable[None]],
     sync_spawn: Callable,
     call_soon: Callable,
 ) -> None:
+    app_send_channel, app_receive_channel = channels
     try:
-        await app(scope, receive, send, sync_spawn, call_soon)
+        async with app_send_channel, app_receive_channel:
+            receive = cast("ASGIReceiveCallable", app_receive_channel.receive)
+            await app(scope, receive, send, sync_spawn, call_soon)
     except anyio.get_cancelled_exc_class():
         raise
     except BaseExceptionGroup as error:
@@ -74,12 +82,18 @@ class TaskGroup:
             app,
             config,
             scope,
-            app_receive_channel.receive,
+            (app_send_channel, app_receive_channel),
             send,
             anyio.to_thread.run_sync,
             anyio.from_thread.run,
         )
-        return app_send_channel.send
+
+        async def put(message: ASGIReceiveEvent) -> None:
+            # The app has finished if the channel is closed, so it will read no more messages
+            with suppress(anyio.BrokenResourceError, anyio.ClosedResourceError):
+                await app_send_channel.send(message)
+
+        return put
 
     def spawn(self, func: Callable, *args: Any) -> None:  # noqa: ANN401
         """Spawn an arbitrary coroutine function in the task group."""

--- a/tests/e2e/test_httpx.py
+++ b/tests/e2e/test_httpx.py
@@ -51,12 +51,11 @@ async def test_keep_alive_max_requests_regression() -> None:
 
         await anyio.wait_all_tasks_blocked()
 
-        client = httpx.AsyncClient()
-
-        # Make sure that we properly clean up connections when `keep_alive_max_requests`
-        # is hit such that the client stays good over multiple hangups.
-        for _ in range(10):
-            result = await client.post("http://127.0.0.1:1234/test", json={"key": "value"})
-            result.raise_for_status()
+        async with httpx.AsyncClient() as client:
+            # Make sure that we properly clean up connections when `keep_alive_max_requests`
+            # is hit such that the client stays good over multiple hangups.
+            for _ in range(10):
+                result = await client.post("http://127.0.0.1:1234/test", json={"key": "value"})
+                result.raise_for_status()
 
         shutdown.set()

--- a/tests/protocol/test_h11.py
+++ b/tests/protocol/test_h11.py
@@ -299,8 +299,8 @@ async def test_protocol_handle_send_client_error(protocol: H11Protocol) -> None:
 
 @pytest.mark.anyio
 async def test_protocol_handle_pipelining(protocol: H11Protocol) -> None:
-    protocol.can_read.wait.side_effect = Exception()
-    with pytest.raises(Exception, match=""):  # noqa: PT011
+    protocol.can_read.wait.side_effect = Exception("pipelining")
+    with pytest.raises(Exception, match="pipelining"):
         await protocol.handle(
             RawData(
                 data=b"GET / HTTP/1.1\r\nHost: anycorn\r\nConnection: keep-alive\r\n\r\n"

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -475,14 +475,15 @@ async def test_abnormal_close_logging() -> None:
         None,
     )
 
-    await stream.handle(
-        Request(
-            stream_id=1,
-            http_version="2",
-            headers=[],
-            raw_path=b"/?a=b",
-            method="GET",
-            state=ConnectionState({}),
+    async with config.log:
+        await stream.handle(
+            Request(
+                stream_id=1,
+                http_version="2",
+                headers=[],
+                raw_path=b"/?a=b",
+                method="GET",
+                state=ConnectionState({}),
+            )
         )
-    )
-    await stream.handle(StreamClosed(stream_id=1))
+        await stream.handle(StreamClosed(stream_id=1))

--- a/tests/test_app_wrappers.py
+++ b/tests/test_app_wrappers.py
@@ -54,7 +54,6 @@ async def test_wsgi() -> None:
         "state": ConnectionState({}),
     }
     send_channel, receive_channel = anyio.create_memory_object_stream[ASGIReceiveEvent](1)
-    await send_channel.send({"type": "http.request"})  # type: ignore[arg-type, misc]
 
     messages = []
 
@@ -62,8 +61,10 @@ async def test_wsgi() -> None:
         nonlocal messages
         messages.append(message)
 
-    receive = cast("ASGIReceiveCallable", receive_channel.receive)
-    await app(scope, receive, _send, anyio.to_thread.run_sync, anyio.from_thread.run)
+    async with send_channel, receive_channel:
+        await send_channel.send({"type": "http.request"})  # type: ignore[arg-type, misc]
+        receive = cast("ASGIReceiveCallable", receive_channel.receive)
+        await app(scope, receive, _send, anyio.to_thread.run_sync, anyio.from_thread.run)
     assert messages == [
         {
             "headers": [
@@ -80,7 +81,6 @@ async def test_wsgi() -> None:
 
 async def _run_app(app: WSGIWrapper, scope: HTTPScope, body: bytes = b"") -> list[ASGISendEvent]:
     send_stream, recv_stream = anyio.create_memory_object_stream[dict](math.inf)
-    await send_stream.send({"type": "http.request", "body": body})
 
     messages = []
 
@@ -91,8 +91,10 @@ async def _run_app(app: WSGIWrapper, scope: HTTPScope, body: bytes = b"") -> lis
     def _call_soon(func: Callable, *args: Any) -> Any:  # noqa: ANN401
         return anyio.from_thread.run(func, *args)
 
-    receive = cast("ASGIReceiveCallable", recv_stream.receive)
-    await app(scope, receive, _send, anyio.to_thread.run_sync, _call_soon)
+    async with send_stream, recv_stream:
+        await send_stream.send({"type": "http.request", "body": body})
+        receive = cast("ASGIReceiveCallable", recv_stream.receive)
+        await app(scope, receive, _send, anyio.to_thread.run_sync, _call_soon)
     return messages
 
 

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, cast
 
 import anyio
@@ -40,8 +41,13 @@ async def test_asyncio_sender_releases_socket() -> None:
 
 
 @pytest.mark.anyio
-async def test_anyio_sender_releases_socket() -> None:
+async def test_anyio_sender_releases_socket(anyio_backend_name: str) -> None:
     """The sender used on every platform other than Windows."""
+    if sys.platform == "win32" and anyio_backend_name == "asyncio":
+        # This is the combination StatsdLogger avoids: anyio's aclose() waits for a
+        # connection_lost() the proactor loop never delivers, so it would hang here
+        pytest.skip("anyio's UDP aclose() hangs on the proactor event loop")
+
     sender = await _AnyioSender.create("127.0.0.1", 9125)
     raw = cast("socket.socket", sender._socket.extra(SocketAttribute.raw_socket))  # noqa: S610
     await sender.send(b"anycorn.test:1|c")

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -1,0 +1,63 @@
+"""Tests for the statsd logger's UDP senders."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import anyio
+import pytest
+from anyio.abc import SocketAttribute
+
+from anycorn.config import Config
+from anycorn.statsd import StatsdLogger, _AnyioSender, _AsyncioSender
+
+if TYPE_CHECKING:
+    import socket
+
+
+def _raw_socket(logger: StatsdLogger) -> socket.socket:
+    sender = logger._sender
+    if isinstance(sender, _AsyncioSender):
+        return cast("socket.socket", sender._transport.get_extra_info("socket"))
+
+    assert isinstance(sender, _AnyioSender)
+    return cast("socket.socket", sender._socket.extra(SocketAttribute.raw_socket))  # noqa: S610
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_asyncio_sender_releases_socket() -> None:
+    """The Windows sender must neither leak its socket nor hang after a send.
+
+    Only reached on Windows in production, so exercise it everywhere: on the proactor
+    loop `transport.close()` alone leaves the socket open whilst a write is in flight.
+    """
+    sender = await _AsyncioSender.create("127.0.0.1", 9125)
+    raw = cast("socket.socket", sender._transport.get_extra_info("socket"))
+    await sender.send(b"anycorn.test:1|c")
+    await sender.aclose()
+    assert raw.fileno() == -1
+
+
+@pytest.mark.anyio
+async def test_anyio_sender_releases_socket() -> None:
+    """The sender used on every platform other than Windows."""
+    sender = await _AnyioSender.create("127.0.0.1", 9125)
+    raw = cast("socket.socket", sender._socket.extra(SocketAttribute.raw_socket))  # noqa: S610
+    await sender.send(b"anycorn.test:1|c")
+    await sender.aclose()
+    assert raw.fileno() == -1
+
+
+@pytest.mark.anyio
+async def test_aclose_forcefully_releases_socket() -> None:
+    """Closing in a cancelled scope must still release the socket."""
+    config = Config()
+    config.statsd_host = "localhost:9125"
+    logger = StatsdLogger(config)
+    await logger.increment("anycorn.test", 1)
+    raw = _raw_socket(logger)
+
+    await anyio.aclose_forcefully(logger)
+
+    assert raw.fileno() == -1

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -3,26 +3,12 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, cast
 
 import anyio
 import pytest
-from anyio.abc import SocketAttribute
 
 from anycorn.config import Config
 from anycorn.statsd import StatsdLogger, _AnyioSender, _AsyncioSender
-
-if TYPE_CHECKING:
-    import socket
-
-
-def _raw_socket(logger: StatsdLogger) -> socket.socket:
-    sender = logger._sender
-    if isinstance(sender, _AsyncioSender):
-        return cast("socket.socket", sender._transport.get_extra_info("socket"))
-
-    assert isinstance(sender, _AnyioSender)
-    return cast("socket.socket", sender._socket.extra(SocketAttribute.raw_socket))  # noqa: S610
 
 
 @pytest.mark.anyio
@@ -34,10 +20,9 @@ async def test_asyncio_sender_releases_socket() -> None:
     loop `transport.close()` alone leaves the socket open whilst a write is in flight.
     """
     sender = await _AsyncioSender.create("127.0.0.1", 9125)
-    raw = cast("socket.socket", sender._transport.get_extra_info("socket"))
     await sender.send(b"anycorn.test:1|c")
     await sender.aclose()
-    assert raw.fileno() == -1
+    assert sender.socket.fileno() == -1
 
 
 @pytest.mark.anyio
@@ -49,10 +34,9 @@ async def test_anyio_sender_releases_socket(anyio_backend_name: str) -> None:
         pytest.skip("anyio's UDP aclose() hangs on the proactor event loop")
 
     sender = await _AnyioSender.create("127.0.0.1", 9125)
-    raw = cast("socket.socket", sender._socket.extra(SocketAttribute.raw_socket))  # noqa: S610
     await sender.send(b"anycorn.test:1|c")
     await sender.aclose()
-    assert raw.fileno() == -1
+    assert sender.socket.fileno() == -1
 
 
 @pytest.mark.anyio
@@ -62,8 +46,9 @@ async def test_aclose_forcefully_releases_socket() -> None:
     config.statsd_host = "localhost:9125"
     logger = StatsdLogger(config)
     await logger.increment("anycorn.test", 1)
-    raw = _raw_socket(logger)
+    sender = logger._sender
+    assert sender is not None
 
     await anyio.aclose_forcefully(logger)
 
-    assert raw.fileno() == -1
+    assert sender.socket.fileno() == -1

--- a/uv.lock
+++ b/uv.lock
@@ -91,7 +91,7 @@ dev = [
     { name = "anycorn", extras = ["h3"] },
     { name = "httpx" },
     { name = "mock" },
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.6" },
     { name = "trio" },
     { name = "ty", specifier = ">=0.0.22" },
@@ -100,7 +100,7 @@ test = [
     { name = "anycorn", extras = ["h3"] },
     { name = "httpx" },
     { name = "mock" },
-    { name = "pytest" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "trio" },
 ]
 
@@ -310,7 +310,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -545,7 +545,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -556,9 +556,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -106,17 +106,16 @@ test = [
 
 [[package]]
 name = "anyio"
-version = "4.11.0"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
-    { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #38 

Enables `-W error` with pytest 9, which turns the ResourceWarnings emitted by a handful of real leaks into test failures, then fixes them.

## Library

- **`TaskGroup.spawn_app`** created a memory object stream pair per request and never closed either end. `_handle` now owns both and closes them once the app returns. The returned `put` suppresses `BrokenResourceError`/`ClosedResourceError` so protocols can still fire `http.disconnect`/`websocket.disconnect` after the app has exited — previously those messages accumulated in a queue nobody would drain, and `put` would block once it filled.
- **`worker_serve`** never closed its listeners, leaking the listening sockets. They're now entered into an `AsyncExitStack` nested inside the server task group, so they close before the graceful-shutdown wait.
- **`DispatcherMiddleware`** leaked its per-mount lifespan channels.
- **`Logger`** gains `aclose()` and subclasses `anyio.abc.AsyncResource` for the async context manager protocol; `worker_serve` closes the logger on the way out.

## Windows: statsd socket

`StatsdLogger` sends a metric and then closes its socket, which turns out to be the exact shape of an anyio bug — reported as **agronholm/anyio#1237**, with a reproducer and CI matrix at [graingert/anyio-udp-aclose-hang](https://github.com/graingert/anyio-udp-aclose-hang).

anyio's UDP `aclose()` waits for `connection_lost()`, which the proactor event loop never schedules when a write is in flight: `close()` skips it because `_write_fut` is set, and the write's callback then bails on the `_conn_lost` that `close()` just incremented. Before anyio 4.14 that was a leaked descriptor; since 4.14 it is a deadlock.

So on Windows the logger drives asyncio's `DatagramProtocol` directly, which reaches the `abort()` anyio's wrapper does not expose. Unlike `close()`, `_force_close()` only bails once `connection_lost()` has actually been called, so it always schedules it and the wait cannot deadlock. It runs in a `finally`, and the wait is shielded, so a cancelled close still releases the socket. Selected with sniffio and confined to Windows — every other platform keeps using anyio. `send()` waits on the transport's `pause_writing`/`resume_writing` event, matching the flow control anyio's own `send()` applies.

## Dependencies

anyio 4.11 → 4.14.2 in the lockfile only (the declared `>=4.0` floor is untouched), for the FD-release fix in anyio#1147. 4.14 also narrowed `TaskGroup.start_soon` to require a callable returning a `Coroutine` rather than an `Awaitable`, so `DispatcherMiddleware` now calls the mounted app through a coroutine function.

## Tests

An unclosed `httpx.AsyncClient` in the e2e test and two leaked stream pairs in the app-wrapper helpers. pytest 9 also rejects the always-passing `pytest.raises(..., match="")` in the h11 pipelining test, which now matches a real message. New `tests/test_statsd.py` covers both senders and `aclose_forcefully()`; the anyio sender test skips on Windows asyncio, since that combination is precisely the one the logger routes around and it would hang rather than fail.

## Note on the `put` behaviour change

Sends after the app coroutine has returned are now dropped rather than buffered. The ASGI spec is silent on server obligations after the callable returns, but it defines `http.disconnect` as "sent to the application *if receive is called* after a response has been sent" — i.e. pull-driven, so queueing it for an app that has already returned delivers to nobody. The channel closes only after `await app(...)` returns, raises, or is cancelled, so an app still running that calls `receive()` late still gets its disconnect.

One pre-existing hazard is unchanged: if a running app never calls `receive()` and the bounded queue (`max_app_queue_size`) fills, `put` still blocks the protocol task.

---

Green across the full matrix — ubuntu, macos and windows on 3.10 through 3.14 — plus lint, pre-commit, h2spec and autobahn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)