### PR TITLE
Add sniffio as a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "hpack",
     "anyio >=4.0,<5.0",
     "priority",
+    "sniffio >=1.1,<2.0",
     "tomli; python_version<'3.11'",
     "typing_extensions; python_version<'3.11'",
     "wsproto >=0.14.0",

--- a/uv.lock
+++ b/uv.lock
@@ -42,6 +42,7 @@ dependencies = [
     { name = "hpack" },
     { name = "priority" },
     { name = "rich-click" },
+    { name = "sniffio" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "wsproto" },
@@ -80,6 +81,7 @@ requires-dist = [
     { name = "hpack" },
     { name = "priority" },
     { name = "rich-click", specifier = ">=1.8.3,<2.0.0" },
+    { name = "sniffio", specifier = ">=1.1,<2.0" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "wsproto", specifier = ">=0.14.0" },
@@ -309,7 +311,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [


### PR DESCRIPTION
sniffio is imported directly in src/anycorn/statsd.py but was only present transitively via anyio. Constrain to >=1.1,<2.0: 1.1.0 introduced current_async_library(), which anycorn relies on, and <2.0 guards against a breaking major bump.