### PR TITLE
Serve HTTP/3, and fix what testing it turned up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ test = [
     "pytest>=9.1.1",
     "mock",
     "trio",
+    "trustme",
 ]
 dev = [
     { include-group = "test" },

--- a/src/anycorn/datagram.py
+++ b/src/anycorn/datagram.py
@@ -1,0 +1,165 @@
+"""Datagram sockets that close deterministically on every platform.
+
+anyio's UDP `aclose()` waits for a `connection_lost()` that the proactor event loop
+never schedules whilst a write is in flight, so on Windows it hangs forever and leaves
+the socket open (agronholm/anyio#1237). asyncio's transport exposes `abort()`, which
+carries no such condition, so on Windows these drive asyncio directly; everywhere else
+they are a thin wrapper over anyio.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+from collections import deque
+from typing import TYPE_CHECKING
+
+import anyio
+import anyio.abc
+import sniffio
+from anyio.abc import SocketAttribute
+
+if TYPE_CHECKING:
+    IPAddress = tuple[str, int]
+
+
+def _needs_asyncio() -> bool:
+    return sys.platform == "win32" and sniffio.current_async_library() == "asyncio"
+
+
+class _DatagramProtocol(asyncio.DatagramProtocol):
+    def __init__(self) -> None:
+        self.read_queue: deque[tuple[bytes, IPAddress]] = deque()
+        self.read_event = asyncio.Event()
+        self.write_event = asyncio.Event()
+        self.closed = asyncio.Event()
+        self.write_event.set()
+
+    def datagram_received(self, data: bytes, addr: IPAddress) -> None:
+        self.read_queue.append((data, addr))
+        self.read_event.set()
+
+    def error_received(self, exc: Exception) -> None:
+        """Ignore ICMP errors, as a datagram server cannot act on them."""
+
+    def pause_writing(self) -> None:
+        self.write_event.clear()
+
+    def resume_writing(self) -> None:
+        self.write_event.set()
+
+    def connection_lost(self, exc: Exception | None) -> None:  # noqa: ARG002
+        self.read_event.set()
+        self.write_event.set()
+        self.closed.set()
+
+
+class _AsyncioDatagramSocket:
+    """Datagram socket driven through asyncio, so that the transport can be aborted."""
+
+    def __init__(self, transport: asyncio.DatagramTransport, protocol: _DatagramProtocol) -> None:
+        self._transport = transport
+        self._protocol = protocol
+        self.socket: socket.socket = transport.get_extra_info("socket")
+
+    @classmethod
+    async def connect(cls, host: str, port: int) -> _AsyncioDatagramSocket:
+        transport, protocol = await asyncio.get_running_loop().create_datagram_endpoint(
+            _DatagramProtocol, remote_addr=(host, port), family=socket.AddressFamily.AF_INET
+        )
+        return cls(transport, protocol)
+
+    @classmethod
+    async def from_socket(cls, sock: socket.socket) -> _AsyncioDatagramSocket:
+        transport, protocol = await asyncio.get_running_loop().create_datagram_endpoint(
+            _DatagramProtocol, sock=sock
+        )
+        return cls(transport, protocol)
+
+    async def receive(self) -> tuple[bytes, IPAddress]:
+        while not self._protocol.read_queue:
+            if self._protocol.closed.is_set():
+                raise anyio.ClosedResourceError
+
+            self._protocol.read_event.clear()
+            await self._protocol.read_event.wait()
+
+        return self._protocol.read_queue.popleft()
+
+    async def send(self, data: bytes) -> None:
+        await self._protocol.write_event.wait()
+        self._transport.sendto(data)
+
+    async def sendto(self, data: bytes, host: str, port: int) -> None:
+        await self._protocol.write_event.wait()
+        self._transport.sendto(data, (host, port))
+
+    async def aclose(self) -> None:
+        self._transport.close()
+        try:
+            # Give a completing write the chance to close the transport by itself
+            await asyncio.sleep(0)
+        finally:
+            # Unlike close(), abort() always schedules connection_lost, so this must run
+            # even if the checkpoint above is cancelled. Having scheduled it, the wait is
+            # bounded by a single iteration of the loop, so shield it: a cancelled close
+            # must still leave the socket released.
+            self._transport.abort()
+            with anyio.CancelScope(shield=True):
+                await self._protocol.closed.wait()
+
+
+class _AnyioDatagramSocket:
+    """Datagram socket backed by anyio, used wherever its `aclose()` is sound.
+
+    `connect()` leaves the socket unconnected and addresses each datagram instead. A
+    connected UDP socket is told about ICMP port unreachable, so a peer that is down -
+    a statsd daemon, say - surfaces as ECONNREFUSED on a later send, which anyio raises
+    as `BrokenResourceError` from whichever caller happened to be sending at the time.
+    """
+
+    def __init__(self, sock: anyio.abc.UDPSocket, remote: IPAddress | None = None) -> None:
+        self._socket = sock
+        self._remote = remote
+        self.socket: socket.socket = sock.extra(SocketAttribute.raw_socket)  # noqa: S610
+
+    @classmethod
+    async def connect(cls, host: str, port: int) -> _AnyioDatagramSocket:
+        return cls(await anyio.create_udp_socket(family=socket.AddressFamily.AF_INET), (host, port))
+
+    @classmethod
+    async def from_socket(cls, sock: socket.socket) -> _AnyioDatagramSocket:
+        return cls(await anyio.abc.UDPSocket.from_socket(sock))
+
+    async def receive(self) -> tuple[bytes, IPAddress]:
+        return await self._socket.receive()
+
+    async def send(self, data: bytes) -> None:
+        assert self._remote is not None
+        await self._socket.sendto(data, *self._remote)
+
+    async def sendto(self, data: bytes, host: str, port: int) -> None:
+        await self._socket.sendto(data, host, port)
+
+    async def aclose(self) -> None:
+        await self._socket.aclose()
+
+
+DatagramSocket = _AsyncioDatagramSocket | _AnyioDatagramSocket
+
+
+async def connect_datagram_socket(host: str, port: int) -> DatagramSocket:
+    """Open a datagram socket connected to the given address."""
+    if _needs_asyncio():
+        return await _AsyncioDatagramSocket.connect(host, port)
+
+    return await _AnyioDatagramSocket.connect(host, port)
+
+
+async def wrap_datagram_socket(sock: socket.socket) -> DatagramSocket:
+    """Adopt an existing datagram socket, taking ownership of it."""
+    if _needs_asyncio():
+        return await _AsyncioDatagramSocket.from_socket(sock)
+
+    return await _AnyioDatagramSocket.from_socket(sock)

--- a/src/anycorn/datagram.py
+++ b/src/anycorn/datagram.py
@@ -137,7 +137,8 @@ class _AnyioDatagramSocket:
 
     async def send(self, data: bytes) -> None:
         assert self._remote is not None
-        await self._socket.sendto(data, *self._remote)
+        host, port = self._remote
+        await self._socket.sendto(data, host, port)
 
     async def sendto(self, data: bytes, host: str, port: int) -> None:
         await self._socket.sendto(data, host, port)

--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote
 from anycorn.typing import (
     AppWrapper,
     ASGISendEvent,
+    ConnectionState,
     Extensions,
     HTTPResponseStartEvent,
     HTTPScope,
@@ -131,7 +132,10 @@ class HTTPStream:
                 headers=event.headers,
                 client=self.client,
                 server=self.server,
-                state=event.state,
+                # Per request, not per connection: ASGI passes a shallow copy into
+                # each request, so what one request stores cannot reach the next one
+                # sharing the connection
+                state=ConnectionState(event.state.copy()),
                 extensions=extensions,
             )
 

--- a/src/anycorn/protocol/quic.py
+++ b/src/anycorn/protocol/quic.py
@@ -170,7 +170,10 @@ class QuicProtocol:
                     self.config,
                     self.context,
                     self.task_group,
-                    self.state,
+                    # Copied per connection, as TCPServer does. One UDP socket carries
+                    # every QUIC connection it is sent, so sharing the worker's state
+                    # would hand one client's namespace to the next
+                    ConnectionState(self.state.copy()),
                     tls_extension,
                     client,
                     self.server,

--- a/src/anycorn/protocol/ws_stream.py
+++ b/src/anycorn/protocol/ws_stream.py
@@ -36,6 +36,9 @@ from anycorn.typing import (
     WebsocketScope,
     WorkerContext,
 )
+from anycorn.typing import (
+    ConnectionState as ASGIConnectionState,  # wsproto has one of its own
+)
 from anycorn.utils import (
     UnexpectedMessageError,
     build_and_validate_headers,
@@ -263,7 +266,9 @@ class WSStream:
                 "headers": event.headers,
                 "client": self.client,
                 "server": self.server,
-                "state": event.state,
+                # Per request: ASGI passes a shallow copy into each connection, so
+                # what one stores cannot reach the next sharing the connection
+                "state": ASGIConnectionState(event.state.copy()),
                 "subprotocols": self.handshake.subprotocols or [],
                 "extensions": extensions,
             }

--- a/src/anycorn/run.py
+++ b/src/anycorn/run.py
@@ -84,7 +84,7 @@ def run(config: Config) -> int:  # noqa: C901, PLR0912
             shutdown_event = ctx.Event()
 
             def shutdown(*_args: Any) -> None:  # noqa: ANN401
-                nonlocal active, shutdown_event
+                nonlocal active
                 shutdown_event.set()
                 active = False
 

--- a/src/anycorn/run.py
+++ b/src/anycorn/run.py
@@ -6,7 +6,7 @@ import platform
 import signal
 import sys
 import time
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, ExitStack
 from functools import partial
 from multiprocessing import get_context
 from multiprocessing.connection import wait
@@ -58,76 +58,76 @@ def run(config: Config) -> int:  # noqa: C901, PLR0912
 
     sockets = config.create_sockets()
 
-    if config.use_reloader and config.workers == 0:
-        msg = "Cannot reload without workers"
-        raise RuntimeError(msg)
+    with ExitStack() as cleanup_stack:
+        # Whatever happens next - a worker failing to spawn, the reloader raising -
+        # the parent is left holding these, and each is closed independently so one
+        # refusing does not strand the rest
+        for sock in (*sockets.secure_sockets, *sockets.insecure_sockets, *sockets.quic_sockets):
+            cleanup_stack.enter_context(sock)
 
-    exitcode = 0
-    if config.workers == 0:
-        worker_func(config, sockets)
-    else:
-        if config.use_reloader:
-            # Load the application so that the correct paths are checked for
-            # changes, but only when the reloader is being used.
-            load_application(config.application_path, config.wsgi_max_body_size)
+        if config.use_reloader and config.workers == 0:
+            msg = "Cannot reload without workers"
+            raise RuntimeError(msg)
 
-        ctx = get_context("spawn")
-
-        active = True
-        shutdown_event = ctx.Event()
-
-        def shutdown(*_args: Any) -> None:  # noqa: ANN401
-            nonlocal active, shutdown_event
-            shutdown_event.set()
-            active = False
-
-        processes: list[BaseProcess] = []
-        while active:
-            # Ignore SIGINT before creating the processes, so that they
-            # inherit the signal handling. This means that the shutdown
-            # function controls the shutdown.
-            signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-            _populate(processes, config, worker_func, sockets, shutdown_event, ctx)
-
-            for signal_name in ("SIGINT", "SIGTERM", "SIGBREAK"):
-                if hasattr(signal, signal_name):
-                    signal.signal(getattr(signal, signal_name), shutdown)
-
+        exitcode = 0
+        if config.workers == 0:
+            worker_func(config, sockets)
+        else:
             if config.use_reloader:
-                files = files_to_watch()
-                while True:
-                    finished = wait((process.sentinel for process in processes), timeout=1)
-                    updated = check_for_updates(files)
-                    if updated:
-                        shutdown_event.set()
-                        for process in processes:
-                            process.join()
-                        shutdown_event.clear()
-                        break
-                    if len(finished) > 0:
-                        break
-            else:
-                wait(process.sentinel for process in processes)
+                # Load the application so that the correct paths are checked for
+                # changes, but only when the reloader is being used.
+                load_application(config.application_path, config.wsgi_max_body_size)
 
-            exitcode = _join_exited(processes)
-            if exitcode != 0:
+            ctx = get_context("spawn")
+
+            active = True
+            shutdown_event = ctx.Event()
+
+            def shutdown(*_args: Any) -> None:  # noqa: ANN401
+                nonlocal active, shutdown_event
                 shutdown_event.set()
                 active = False
 
-        for process in processes:
-            process.terminate()
+            processes: list[BaseProcess] = []
+            # Registered after the sockets, so it unwinds first: signal the children,
+            # then close what the parent is still holding. A worker that fails to
+            # spawn would otherwise leave its siblings running
+            cleanup_stack.callback(_terminate, processes)
+            while active:
+                # Ignore SIGINT before creating the processes, so that they
+                # inherit the signal handling. This means that the shutdown
+                # function controls the shutdown.
+                signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-        exitcode = _join_exited(processes) if exitcode != 0 else exitcode
+                _populate(processes, config, worker_func, sockets, shutdown_event, ctx)
 
-        _close_sockets(sockets)
+                for signal_name in ("SIGINT", "SIGTERM", "SIGBREAK"):
+                    if hasattr(signal, signal_name):
+                        signal.signal(getattr(signal, signal_name), shutdown)
 
-    return exitcode
+                if config.use_reloader:
+                    files = files_to_watch()
+                    while True:
+                        finished = wait((process.sentinel for process in processes), timeout=1)
+                        updated = check_for_updates(files)
+                        if updated:
+                            shutdown_event.set()
+                            for process in processes:
+                                process.join()
+                            shutdown_event.clear()
+                            break
+                        if len(finished) > 0:
+                            break
+                else:
+                    wait(process.sentinel for process in processes)
 
+                exitcode = _join_exited(processes)
+                if exitcode != 0:
+                    shutdown_event.set()
+                    active = False
 
-def _close_sockets(sockets: Sockets) -> None:
-    for sock in (*sockets.secure_sockets, *sockets.insecure_sockets, *sockets.quic_sockets):
-        sock.close()
+            exitcode = _join_exited(processes) if exitcode != 0 else exitcode
+        return exitcode
 
 
 def _populate(  # noqa: PLR0913
@@ -152,6 +152,12 @@ def _populate(  # noqa: PLR0913
         processes.append(process)
         if platform.system() == "Windows":
             time.sleep(0.1)
+
+
+def _terminate(processes: list[BaseProcess]) -> None:
+    """Signal every worker still running. Reaped ones have already left the list."""
+    for process in processes:
+        process.terminate()
 
 
 def _join_exited(processes: list[BaseProcess]) -> int:

--- a/src/anycorn/run.py
+++ b/src/anycorn/run.py
@@ -18,10 +18,12 @@ import anyio
 import anyio.abc
 import anyio.streams.tls
 
+from .datagram import wrap_datagram_socket
 from .lifespan import Lifespan
 from .statsd import StatsdLogger
 from .tcp_server import tcp_server_handler
 from .typing import AppWrapper, ConnectionState, LifespanState, WorkerFunc
+from .udp_server import UDPServer
 from .utils import (
     ShutdownError,
     check_for_updates,
@@ -118,13 +120,14 @@ def run(config: Config) -> int:  # noqa: C901, PLR0912
 
         exitcode = _join_exited(processes) if exitcode != 0 else exitcode
 
-        for sock in sockets.secure_sockets:
-            sock.close()
-
-        for sock in sockets.insecure_sockets:
-            sock.close()
+        _close_sockets(sockets)
 
     return exitcode
+
+
+def _close_sockets(sockets: Sockets) -> None:
+    for sock in (*sockets.secure_sockets, *sockets.insecure_sockets, *sockets.quic_sockets):
+        sock.close()
 
 
 def _populate(  # noqa: PLR0913
@@ -163,7 +166,7 @@ def _join_exited(processes: list[BaseProcess]) -> int:
     return exitcode
 
 
-async def worker_serve(  # noqa: C901, PLR0915
+async def worker_serve(  # noqa: C901, PLR0912, PLR0915
     app: AppWrapper,
     config: Config,
     *,
@@ -185,7 +188,7 @@ async def worker_serve(  # noqa: C901, PLR0915
         await lifespan_tg.start(lifespan.handle_lifespan)
         await lifespan.wait_for_startup()
 
-        async with anyio.create_task_group() as server_tg, AsyncExitStack() as listener_stack:
+        async with anyio.create_task_group() as server_tg, AsyncExitStack() as socket_stack:
             if sockets is None:
                 sockets = config.create_sockets()
                 for sock in sockets.secure_sockets:
@@ -205,7 +208,7 @@ async def worker_serve(  # noqa: C901, PLR0915
                     True,  # noqa: FBT003
                     config.ssl_handshake_timeout,
                 )
-                listeners.append(await listener_stack.enter_async_context(secure_listener))
+                listeners.append(await socket_stack.enter_async_context(secure_listener))
                 bind = repr_socket_addr(secure_sock.family, secure_sock.getsockname())
                 url = f"https://{bind}"
                 binds.append(url)
@@ -214,11 +217,23 @@ async def worker_serve(  # noqa: C901, PLR0915
             for insecure_sock in sockets.insecure_sockets:
                 asynclib = anyio._core._eventloop.get_async_backend()  # noqa: SLF001  # ty:ignore[possibly-missing-attribute]
                 insecure_listener = asynclib.create_tcp_listener(insecure_sock)
-                listeners.append(await listener_stack.enter_async_context(insecure_listener))
+                listeners.append(await socket_stack.enter_async_context(insecure_listener))
                 bind = repr_socket_addr(insecure_sock.family, insecure_sock.getsockname())
                 url = f"http://{bind}"
                 binds.append(url)
                 await config.log.info("Running on %s (CTRL + C to quit)", url)
+
+            udp_servers = []
+            for quic_sock in sockets.quic_sockets:
+                udp_socket = await wrap_datagram_socket(quic_sock)
+                socket_stack.push_async_callback(udp_socket.aclose)
+                udp_servers.append(
+                    UDPServer(app, config, context, lifespan_state.copy(), udp_socket)
+                )
+                bind = repr_socket_addr(quic_sock.family, quic_sock.getsockname())
+                url = f"https://{bind}"
+                binds.append(url)
+                await config.log.info("Running on %s (QUIC, CTRL + C to quit)", url)
 
             task_status.started(binds)
             try:
@@ -226,6 +241,9 @@ async def worker_serve(  # noqa: C901, PLR0915
                     if shutdown_trigger is not None:
                         tg.start_soon(raise_shutdown, shutdown_trigger)
                     tg.start_soon(raise_shutdown, context.terminate.wait)
+
+                    for udp_server in udp_servers:
+                        await tg.start(udp_server.run)
 
                     for listener in listeners:
                         tg.start_soon(

--- a/src/anycorn/statsd.py
+++ b/src/anycorn/statsd.py
@@ -2,16 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
-import socket
-import sys
 from typing import TYPE_CHECKING, Any
 
-import anyio
-import anyio.abc
-import sniffio
-from anyio.abc import SocketAttribute
-
+from .datagram import DatagramSocket, connect_datagram_socket
 from .logging import Logger
 
 if TYPE_CHECKING:
@@ -121,96 +114,6 @@ class BaseStatsdLogger(Logger):
         raise NotImplementedError
 
 
-class _DatagramProtocol(asyncio.DatagramProtocol):
-    def __init__(self) -> None:
-        self.closed = asyncio.Event()
-        self.write_event = asyncio.Event()
-        self.write_event.set()
-
-    def pause_writing(self) -> None:
-        self.write_event.clear()
-
-    def resume_writing(self) -> None:
-        self.write_event.set()
-
-    def connection_lost(self, exc: Exception | None) -> None:  # noqa: ARG002
-        self.write_event.set()
-        self.closed.set()
-
-
-class _AsyncioSender:
-    """Sends datagrams via asyncio, so that the transport can be aborted on close.
-
-    Used only on Windows, where the proactor event loop will not schedule
-    `connection_lost()` from `transport.close()` whilst a write is in flight - leaving
-    the socket unclosed and anyio's `aclose()`, which waits for that event, hanging
-    forever. `abort()` carries no such condition, and anyio's UDP wrapper offers no way
-    to reach it. Every other platform uses `_AnyioSender`.
-    see https://github.com/agronholm/anyio/issues/1237
-    """
-
-    def __init__(self, transport: asyncio.DatagramTransport, protocol: _DatagramProtocol) -> None:
-        self._transport = transport
-        self._protocol = protocol
-        self.socket: socket.socket = transport.get_extra_info("socket")
-
-    @classmethod
-    async def create(cls, host: str, port: int) -> _AsyncioSender:
-        transport, protocol = await asyncio.get_running_loop().create_datagram_endpoint(
-            _DatagramProtocol,
-            remote_addr=(host, port),
-            family=socket.AddressFamily.AF_INET,
-        )
-        return cls(transport, protocol)
-
-    async def send(self, message: bytes) -> None:
-        # Datagram transports have no drain, so this is the transport's high/low water
-        # mark flow control, matching what anyio's own send() waits on
-        await self._protocol.write_event.wait()
-        self._transport.sendto(message)
-
-    async def aclose(self) -> None:
-        self._transport.close()
-        try:
-            # Give a completing write the chance to close the transport by itself
-            await asyncio.sleep(0)
-        finally:
-            # Unlike close(), abort() always schedules connection_lost, so this must
-            # run even if the checkpoint above is cancelled. Having scheduled it, the
-            # wait is bounded by a single iteration of the loop, so shield it: a
-            # cancelled close must still leave the socket released.
-            self._transport.abort()
-            with anyio.CancelScope(shield=True):
-                await self._protocol.closed.wait()
-
-
-class _AnyioSender:
-    """Sends datagrams via anyio, for backends other than asyncio.
-
-    The socket is deliberately left unconnected. A connected UDP socket is told about
-    ICMP port unreachable, surfacing a statsd daemon that is down as ECONNREFUSED on a
-    later send - which anyio raises as `BrokenResourceError`, from whichever request
-    happened to be logging at the time. Metrics are best effort and must not take the
-    request being measured down with them, so address each datagram instead.
-    """
-
-    def __init__(self, sock: anyio.abc.UDPSocket, host: str, port: int) -> None:
-        self._socket = sock
-        self._host = host
-        self._port = port
-        self.socket: socket.socket = sock.extra(SocketAttribute.raw_socket)  # noqa: S610
-
-    @classmethod
-    async def create(cls, host: str, port: int) -> _AnyioSender:
-        return cls(await anyio.create_udp_socket(family=socket.AddressFamily.AF_INET), host, port)
-
-    async def send(self, message: bytes) -> None:
-        await self._socket.sendto(message, self._host, self._port)
-
-    async def aclose(self) -> None:
-        await self._socket.aclose()
-
-
 class StatsdLogger(BaseStatsdLogger):
     """StatsD logger that sends metrics over UDP."""
 
@@ -218,15 +121,11 @@ class StatsdLogger(BaseStatsdLogger):
         super().__init__(config)
         assert config.statsd_host is not None
         self.address = tuple(config.statsd_host.rsplit(":", 1))
-        self._sender: _AsyncioSender | _AnyioSender | None = None
+        self._sender: DatagramSocket | None = None
 
     async def _socket_send(self, message: bytes) -> None:
         if self._sender is None:
-            host, port = self.address[0], int(self.address[1])
-            if sys.platform == "win32" and sniffio.current_async_library() == "asyncio":
-                self._sender = await _AsyncioSender.create(host, port)
-            else:
-                self._sender = await _AnyioSender.create(host, port)
+            self._sender = await connect_datagram_socket(self.address[0], int(self.address[1]))
 
         await self._sender.send(message)
 

--- a/src/anycorn/udp_server.py
+++ b/src/anycorn/udp_server.py
@@ -34,6 +34,10 @@ class UDPServer:
         self.context = context
         self.socket = socket
         self.state = state
+        # QUIC drives sends from the timer and stream tasks as well as from the read
+        # loop, and anyio permits one writer to a socket at a time - concurrent sends
+        # raise BusyResourceError rather than interleaving. Mirrors TCPServer.
+        self.send_lock = anyio.Lock()
 
     async def run(
         self, *, task_status: anyio.abc.TaskStatus[None] = anyio.TASK_STATUS_IGNORED
@@ -64,4 +68,5 @@ class UDPServer:
         """Forward a protocol event back to the UDP socket."""
         if isinstance(event, RawData):
             assert event.address is not None
-            await self.socket.sendto(event.data, event.address[0], event.address[1])
+            async with self.send_lock:
+                await self.socket.sendto(event.data, event.address[0], event.address[1])

--- a/src/anycorn/udp_server.py
+++ b/src/anycorn/udp_server.py
@@ -14,6 +14,7 @@ from .utils import parse_socket_addr
 
 if TYPE_CHECKING:
     from .config import Config
+    from .datagram import DatagramSocket
     from .worker_context import WorkerContext
 
 
@@ -26,7 +27,7 @@ class UDPServer:
         config: Config,
         context: WorkerContext,
         state: LifespanState,
-        socket: anyio.abc.UDPSocket,
+        socket: DatagramSocket,
     ) -> None:
         self.app = app
         self.config = config
@@ -43,10 +44,7 @@ class UDPServer:
         )
 
         task_status.started()
-        server = parse_socket_addr(
-            self.socket.extra(anyio.abc.SocketAttribute.raw_socket).family,  # noqa: S610
-            self.socket.extra(anyio.abc.SocketAttribute.raw_socket).getsockname(),  # noqa: S610
-        )
+        server = parse_socket_addr(self.socket.socket.family, self.socket.socket.getsockname())
         async with TaskGroup() as task_group:
             self.protocol = QuicProtocol(
                 self.app,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,20 +2,51 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import pytest
+import trustme
 
 import anycorn.config
 from anycorn.typing import ConnectionState, HTTPScope
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from _pytest.monkeypatch import MonkeyPatch
+
+
+class TLSCerts(NamedTuple):
+    """Paths to a freshly issued server certificate and the CA that signed it."""
+
+    certfile: Path
+    keyfile: Path
+    cafile: Path
+    hostname: str
 
 
 @pytest.fixture(autouse=True)
 def _time(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(anycorn.config, "time", lambda: 5000)
+
+
+@pytest.fixture(name="tls_certs", scope="session")
+def _tls_certs(tmp_path_factory: pytest.TempPathFactory) -> TLSCerts:
+    """Issue a server certificate for the tests that actually negotiate TLS.
+
+    Generated per run rather than checked in, so there is nothing to expire, and so
+    the clients can verify the chain properly instead of disabling verification.
+    """
+    ca = trustme.CA()
+    hostname = "localhost"
+    server_cert = ca.issue_cert(hostname, "127.0.0.1")
+
+    path = tmp_path_factory.mktemp("tls")
+    certs = TLSCerts(path / "cert.pem", path / "key.pem", path / "ca.pem", hostname)
+    server_cert.cert_chain_pems[0].write_to_path(certs.certfile)
+    server_cert.private_key_pem.write_to_path(certs.keyfile)
+    ca.cert_pem.write_to_path(certs.cafile)
+    return certs
 
 
 @pytest.fixture(name="http_scope")

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -300,7 +300,6 @@ CONCURRENT_REQUESTS = 3
 def _rendezvous_app(
     arrived: list[str],
     clients: list[tuple[str, int] | None],
-    states: list[int],
     released: anyio.Event,
 ) -> Callable:
     """Return an app that answers nothing until every request has arrived.
@@ -314,9 +313,6 @@ def _rendezvous_app(
         assert scope["type"] == "http"
         arrived.append(scope["path"])
         clients.append(scope["client"])
-        # Identity, not contents: ASGI copies this per connection, so one namespace
-        # across all three is the server saying one connection carried them
-        states.append(id(scope["state"]))
         if len(arrived) == CONCURRENT_REQUESTS:
             released.set()
         await released.wait()
@@ -333,13 +329,18 @@ def _rendezvous_app(
 
 
 @pytest.mark.anyio
-async def test_concurrent_requests_share_one_connection(
+async def test_concurrent_requests_are_multiplexed(
     tls_certs: TLSCerts, free_tcp_port: int, free_udp_port: int
 ) -> None:
-    """HTTP/3 multiplexes concurrent requests over a single QUIC connection."""
+    """The server carries concurrent HTTP/3 requests at once, on one connection.
+
+    That there is one connection is the harness's doing - a transport wraps a single
+    QuicConnection on a single socket - so it is the fixed condition here rather than
+    the finding. What is being tested is that the server carries three requests over
+    it simultaneously instead of taking them in turn.
+    """
     arrived: list[str] = []
     clients: list[tuple[str, int] | None] = []
-    states: list[int] = []
     released = anyio.Event()
     responses: dict[str, str] = {}
 
@@ -348,7 +349,7 @@ async def test_concurrent_requests_share_one_connection(
             tls_certs,
             free_tcp_port,
             free_udp_port,
-            _rendezvous_app(arrived, clients, states, released),
+            _rendezvous_app(arrived, clients, released),
         ),
         _H3Transport.connect(HOST, free_udp_port, tls_certs) as transport,
         httpx2.AsyncClient(transport=transport) as client,
@@ -368,12 +369,8 @@ async def test_concurrent_requests_share_one_connection(
     # Every request answered, and answered as itself rather than as a sibling
     assert responses == {path: path for path in paths}
     assert sorted(arrived) == sorted(paths)
-    # One connection served all three, said by the server rather than inferred from
-    # the client: a fresh connection per request would be a namespace per request
-    assert len(set(states)) == 1
-    # The rest describes the harness rather than testing the server - a transport
-    # wraps one QUIC connection on one socket, so it could not have done otherwise.
-    # Kept because it is what makes the assertion above meaningful
+    # The conditions the rendezvous was met under: one socket, one handshake, so the
+    # three were carried together over one connection rather than spread across three
     assert clients == [transport.local_address] * CONCURRENT_REQUESTS
     assert transport.handshakes == 1
 
@@ -404,12 +401,13 @@ async def test_state_is_not_shared_between_connections(
     free_udp_port: int,
     free_udp_port_factory: Callable[[], int],
 ) -> None:
-    """ASGI state is per connection, so one client cannot read the last one's.
+    """One client cannot read what the last one left behind.
 
     Both connections are made from the same client port, so the server sees one
-    address throughout. Anything keyed on where the datagrams came from - a copy per
-    UDP socket, or per peer - would hand the second connection the first's namespace;
-    only keying on the connection itself keeps them apart.
+    address throughout and has nothing to tell them apart by except the connection
+    itself. Copying per request is what enforces this now; the per-connection copy
+    behind it is defence in depth, so this asserts the guarantee rather than either
+    layer.
     """
     seen: list[tuple[str, dict, int, tuple[str, int] | None]] = []
     client_port = free_udp_port_factory()

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -1,0 +1,111 @@
+"""End-to-end HTTP/3 tests, driven by aioquic's client."""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import anyio
+import pytest
+from aioquic.asyncio.client import connect
+from aioquic.asyncio.protocol import QuicConnectionProtocol
+from aioquic.h3.connection import H3_ALPN, H3Connection
+from aioquic.h3.events import DataReceived, HeadersReceived
+from aioquic.quic.configuration import QuicConfiguration
+
+import anycorn
+from anycorn.config import Config
+
+if TYPE_CHECKING:
+    import asyncio
+
+    from aioquic.quic.events import QuicEvent
+
+ASSETS = Path(__file__).parent.parent / "assets"
+BIND = "127.0.0.1:4433"
+
+
+async def app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
+    assert scope["type"] == "http"
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/plain")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"Hello, h3!"})
+
+
+class _H3Client(QuicConnectionProtocol):
+    """The smallest HTTP/3 client that can make one request."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+        super().__init__(*args, **kwargs)
+        self._http = H3Connection(self._quic)
+        self._body = bytearray()
+        self._headers: list[tuple[bytes, bytes]] = []
+        self._done: asyncio.Future[None] = self._loop.create_future()
+
+    def quic_event_received(self, event: QuicEvent) -> None:
+        for h3_event in self._http.handle_event(event):
+            if isinstance(h3_event, HeadersReceived):
+                self._headers = h3_event.headers
+            elif isinstance(h3_event, DataReceived):
+                self._body.extend(h3_event.data)
+
+            if getattr(h3_event, "stream_ended", False) and not self._done.done():
+                self._done.set_result(None)
+
+    async def get(self, path: str) -> tuple[list[tuple[bytes, bytes]], bytes]:
+        stream_id = self._quic.get_next_available_stream_id()
+        self._http.send_headers(
+            stream_id,
+            [
+                (b":method", b"GET"),
+                (b":scheme", b"https"),
+                (b":authority", BIND.encode()),
+                (b":path", path.encode()),
+            ],
+            end_stream=True,
+        )
+        self.transmit()
+        await self._done
+        return self._headers, bytes(self._body)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])  # aioquic's client is asyncio only
+async def test_h3_request() -> None:
+    config = Config()
+    config.bind = [BIND]
+    config.quic_bind = [BIND]
+    config.certfile = str(ASSETS / "cert.pem")
+    config.keyfile = str(ASSETS / "key.pem")
+    config.accesslog = "-"
+    config.errorlog = "-"
+
+    client_config = QuicConfiguration(is_client=True, alpn_protocols=H3_ALPN)
+    client_config.verify_mode = ssl.CERT_NONE
+
+    shutdown = anyio.Event()
+    async with anyio.create_task_group() as tg:
+        binds = await tg.start(
+            lambda *, task_status: anycorn.serve(
+                app, config, shutdown_trigger=shutdown.wait, task_status=task_status
+            )
+        )
+        assert any("4433" in bind for bind in binds)
+
+        async with connect(
+            "127.0.0.1", 4433, configuration=client_config, create_protocol=_H3Client
+        ) as connection:
+            client = cast("_H3Client", connection)
+            with anyio.fail_after(10):
+                headers, body = await client.get("/")
+
+        shutdown.set()
+
+    assert dict(headers)[b":status"] == b"200"
+    assert body == b"Hello, h3!"

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -298,7 +298,10 @@ CONCURRENT_REQUESTS = 3
 
 
 def _rendezvous_app(
-    arrived: list[str], clients: list[tuple[str, int] | None], released: anyio.Event
+    arrived: list[str],
+    clients: list[tuple[str, int] | None],
+    states: list[int],
+    released: anyio.Event,
 ) -> Callable:
     """Return an app that answers nothing until every request has arrived.
 
@@ -311,6 +314,9 @@ def _rendezvous_app(
         assert scope["type"] == "http"
         arrived.append(scope["path"])
         clients.append(scope["client"])
+        # Identity, not contents: ASGI copies this per connection, so one namespace
+        # across all three is the server saying one connection carried them
+        states.append(id(scope["state"]))
         if len(arrived) == CONCURRENT_REQUESTS:
             released.set()
         await released.wait()
@@ -333,6 +339,7 @@ async def test_concurrent_requests_share_one_connection(
     """HTTP/3 multiplexes concurrent requests over a single QUIC connection."""
     arrived: list[str] = []
     clients: list[tuple[str, int] | None] = []
+    states: list[int] = []
     released = anyio.Event()
     responses: dict[str, str] = {}
 
@@ -341,7 +348,7 @@ async def test_concurrent_requests_share_one_connection(
             tls_certs,
             free_tcp_port,
             free_udp_port,
-            _rendezvous_app(arrived, clients, released),
+            _rendezvous_app(arrived, clients, states, released),
         ),
         _H3Transport.connect(HOST, free_udp_port, tls_certs) as transport,
         httpx2.AsyncClient(transport=transport) as client,
@@ -361,10 +368,13 @@ async def test_concurrent_requests_share_one_connection(
     # Every request answered, and answered as itself rather than as a sibling
     assert responses == {path: path for path in paths}
     assert sorted(arrived) == sorted(paths)
-    # Every request came from the one client address, which is the socket the
-    # transport is actually holding - so they shared a UDP flow, seen server side
+    # One connection served all three, said by the server rather than inferred from
+    # the client: a fresh connection per request would be a namespace per request
+    assert len(set(states)) == 1
+    # The rest describes the harness rather than testing the server - a transport
+    # wraps one QUIC connection on one socket, so it could not have done otherwise.
+    # Kept because it is what makes the assertion above meaningful
     assert clients == [transport.local_address] * CONCURRENT_REQUESTS
-    # And a single handshake, so that flow carried one connection rather than three
     assert transport.handshakes == 1
 
 

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -300,6 +300,7 @@ CONCURRENT_REQUESTS = 3
 def _rendezvous_app(
     arrived: list[str],
     clients: list[tuple[str, int] | None],
+    states: list[dict],
     released: anyio.Event,
 ) -> Callable:
     """Return an app that answers nothing until every request has arrived.
@@ -313,6 +314,10 @@ def _rendezvous_app(
         assert scope["type"] == "http"
         arrived.append(scope["path"])
         clients.append(scope["client"])
+        # Held rather than recorded by id: a freed namespace's address can be handed
+        # straight to the next one, so ids only tell them apart whilst all are alive
+        states.append(scope["state"])
+        scope["state"]["secret"] = scope["path"]
         if len(arrived) == CONCURRENT_REQUESTS:
             released.set()
         await released.wait()
@@ -341,6 +346,7 @@ async def test_concurrent_requests_are_multiplexed(
     """
     arrived: list[str] = []
     clients: list[tuple[str, int] | None] = []
+    states: list[dict] = []
     released = anyio.Event()
     responses: dict[str, str] = {}
 
@@ -349,7 +355,7 @@ async def test_concurrent_requests_are_multiplexed(
             tls_certs,
             free_tcp_port,
             free_udp_port,
-            _rendezvous_app(arrived, clients, released),
+            _rendezvous_app(arrived, clients, states, released),
         ),
         _H3Transport.connect(HOST, free_udp_port, tls_certs) as transport,
         httpx2.AsyncClient(transport=transport) as client,
@@ -369,6 +375,11 @@ async def test_concurrent_requests_are_multiplexed(
     # Every request answered, and answered as itself rather than as a sibling
     assert responses == {path: path for path in paths}
     assert sorted(arrived) == sorted(paths)
+    # Sharing the connection is not sharing a namespace: each was handed its own, and
+    # all three were in flight together, so any sharing would have been visible
+    assert len({id(state) for state in states}) == CONCURRENT_REQUESTS
+    assert [state["secret"] for state in states] == arrived
+
     # The conditions the rendezvous was met under: one socket, one handshake, so the
     # three were carried together over one connection rather than spread across three
     assert clients == [transport.local_address] * CONCURRENT_REQUESTS

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -20,7 +20,7 @@ from anycorn.config import Config
 from anycorn.datagram import wrap_datagram_socket
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Callable
 
     from aioquic.h3.events import H3Event
 
@@ -76,10 +76,18 @@ class _H3Transport(httpx2.AsyncBaseTransport):
         self._quic = quic
         self._socket = sock
         self._address = address
-        self._http: H3Connection | None = None
+        # Read now and kept: the socket is gone by the time a test asserts on it
+        host, port = sock.socket.getsockname()[:2]
+        self.local_address = (host, port)
+        # Built now rather than once the handshake lands: the server's control and
+        # QPACK encoder streams arrive with it, and anything received before this
+        # exists is dropped - leaving later responses blocked on dynamic table
+        # entries whose instructions were never seen
+        self._http = H3Connection(quic)
         self._read_queue: dict[int, list[H3Event]] = {}
         self._read_ready: dict[int, anyio.Event] = {}
         self._connected = anyio.Event()
+        self.handshakes = 0
         self._terminated = anyio.Event()
         self._send_lock = anyio.Lock()
 
@@ -109,7 +117,6 @@ class _H3Transport(httpx2.AsyncBaseTransport):
 
                 with anyio.fail_after(10):
                     await self._connected.wait()
-                self._http = H3Connection(quic)
                 await self._transmit()
 
                 try:
@@ -123,7 +130,6 @@ class _H3Transport(httpx2.AsyncBaseTransport):
             await datagram_socket.aclose()
 
     async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
-        assert self._http is not None
         stream_id = self._quic.get_next_available_stream_id()
         self._read_queue[stream_id] = []
         self._read_ready[stream_id] = anyio.Event()
@@ -177,15 +183,15 @@ class _H3Transport(httpx2.AsyncBaseTransport):
         event = self._quic.next_event()
         while event is not None:
             if isinstance(event, HandshakeCompleted):
+                self.handshakes += 1
                 self._connected.set()
             elif isinstance(event, ConnectionTerminated):
                 self._terminated.set()
                 for ready in self._read_ready.values():
                     ready.set()
 
-            if self._http is not None:
-                for h3_event in self._http.handle_event(event):
-                    self._queue_http_event(h3_event)
+            for h3_event in self._http.handle_event(event):
+                self._queue_http_event(h3_event)
 
             event = self._quic.next_event()
 
@@ -245,7 +251,9 @@ class _H3Transport(httpx2.AsyncBaseTransport):
 
 
 @asynccontextmanager
-async def _serving(certs: TLSCerts, tcp_port: int, quic_port: int) -> AsyncIterator[None]:
+async def _serving(
+    certs: TLSCerts, tcp_port: int, quic_port: int, application: Callable = app
+) -> AsyncIterator[None]:
     """Run the worker on the given ports, shutting it down on the way out."""
     config = Config()
     config.bind = [f"{HOST}:{tcp_port}"]
@@ -259,7 +267,7 @@ async def _serving(certs: TLSCerts, tcp_port: int, quic_port: int) -> AsyncItera
     async with anyio.create_task_group() as task_group:
         await task_group.start(
             lambda *, task_status: anycorn.serve(
-                app, config, shutdown_trigger=shutdown.wait, task_status=task_status
+                application, config, shutdown_trigger=shutdown.wait, task_status=task_status
             )
         )
         try:
@@ -282,3 +290,77 @@ async def test_h3_request(tls_certs: TLSCerts, free_tcp_port: int, free_udp_port
     assert response.text == "Hello, h3!"
     assert response.headers["content-type"] == "text/plain"
     assert response.extensions["http_version"] == b"HTTP/3"
+
+
+CONCURRENT_REQUESTS = 3
+
+
+def _rendezvous_app(
+    arrived: list[str], clients: list[tuple[str, int] | None], released: anyio.Event
+) -> Callable:
+    """Return an app that answers nothing until every request has arrived.
+
+    Which only completes if the server is carrying them at once. Were it taking them
+    one at a time - a connection per request, or a stream at a time - the first would
+    sit waiting for siblings that cannot be read yet, and the test would time out.
+    """
+
+    async def _app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
+        assert scope["type"] == "http"
+        arrived.append(scope["path"])
+        clients.append(scope["client"])
+        if len(arrived) == CONCURRENT_REQUESTS:
+            released.set()
+        await released.wait()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": scope["path"].encode()})
+
+    return _app
+
+
+@pytest.mark.anyio
+async def test_concurrent_requests_share_one_connection(
+    tls_certs: TLSCerts, free_tcp_port: int, free_udp_port: int
+) -> None:
+    """HTTP/3 multiplexes concurrent requests over a single QUIC connection."""
+    arrived: list[str] = []
+    clients: list[tuple[str, int] | None] = []
+    released = anyio.Event()
+    responses: dict[str, str] = {}
+
+    async with (
+        _serving(
+            tls_certs,
+            free_tcp_port,
+            free_udp_port,
+            _rendezvous_app(arrived, clients, released),
+        ),
+        _H3Transport.connect(HOST, free_udp_port, tls_certs) as transport,
+        httpx2.AsyncClient(transport=transport) as client,
+    ):
+
+        async def _request(path: str) -> None:
+            response = await client.get(f"https://{HOST}:{free_udp_port}{path}")
+            assert response.status_code == 200  # noqa: PLR2004
+            responses[path] = response.text
+
+        paths = [f"/{index}" for index in range(CONCURRENT_REQUESTS)]
+        with anyio.fail_after(10):
+            async with anyio.create_task_group() as task_group:
+                for path in paths:
+                    task_group.start_soon(_request, path)
+
+    # Every request answered, and answered as itself rather than as a sibling
+    assert responses == {path: path for path in paths}
+    assert sorted(arrived) == sorted(paths)
+    # Every request came from the one client address, which is the socket the
+    # transport is actually holding - so they shared a UDP flow, seen server side
+    assert clients == [transport.local_address] * CONCURRENT_REQUESTS
+    # And a single handshake, so that flow carried one connection rather than three
+    assert transport.handshakes == 1

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -1,29 +1,39 @@
-"""End-to-end HTTP/3 tests, driven by aioquic's client."""
+"""End-to-end HTTP/3 tests, driven by httpx2 over aioquic."""
 
 from __future__ import annotations
 
-import ssl
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+import socket
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
 
 import anyio
+import httpx2
 import pytest
-from aioquic.asyncio.client import connect
-from aioquic.asyncio.protocol import QuicConnectionProtocol
 from aioquic.h3.connection import H3_ALPN, H3Connection
 from aioquic.h3.events import DataReceived, HeadersReceived
 from aioquic.quic.configuration import QuicConfiguration
+from aioquic.quic.connection import QuicConnection
+from aioquic.quic.events import ConnectionTerminated, HandshakeCompleted
 
 import anycorn
 from anycorn.config import Config
+from anycorn.datagram import wrap_datagram_socket
 
 if TYPE_CHECKING:
-    import asyncio
+    from collections.abc import AsyncIterator
 
-    from aioquic.quic.events import QuicEvent
+    from aioquic.h3.events import H3Event
 
-ASSETS = Path(__file__).parent.parent / "assets"
-BIND = "127.0.0.1:4433"
+    from anycorn.datagram import DatagramSocket
+    from tests.conftest import TLSCerts
+
+HOST = "127.0.0.1"
+PORT = 4433
+BIND = f"{HOST}:{PORT}"
+# QUIC drives loss recovery off timers, so one has to be serviced even when no
+# datagram arrives. Polling is coarser than the server's restartable timer task but
+# far harder to get wrong, and on loopback the difference does not show.
+TIMER_INTERVAL = 0.005
 
 
 async def app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
@@ -38,74 +48,240 @@ async def app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
     await send({"type": "http.response.body", "body": b"Hello, h3!"})
 
 
-class _H3Client(QuicConnectionProtocol):
-    """The smallest HTTP/3 client that can make one request."""
+class _H3ResponseStream(httpx2.AsyncByteStream):
+    def __init__(self, aiterator: AsyncIterator[bytes]) -> None:
+        self._aiterator = aiterator
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
-        super().__init__(*args, **kwargs)
-        self._http = H3Connection(self._quic)
-        self._body = bytearray()
-        self._headers: list[tuple[bytes, bytes]] = []
-        self._done: asyncio.Future[None] = self._loop.create_future()
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        async for part in self._aiterator:
+            yield part
 
-    def quic_event_received(self, event: QuicEvent) -> None:
-        for h3_event in self._http.handle_event(event):
-            if isinstance(h3_event, HeadersReceived):
-                self._headers = h3_event.headers
-            elif isinstance(h3_event, DataReceived):
-                self._body.extend(h3_event.data)
 
-            if getattr(h3_event, "stream_ended", False) and not self._done.done():
-                self._done.set_result(None)
+class _H3Transport(httpx2.AsyncBaseTransport):
+    """An httpx2 transport speaking HTTP/3, so a real client drives the server.
 
-    async def get(self, path: str) -> tuple[list[tuple[bytes, bytes]], bytes]:
+    aioquic ships one of these in its examples, but it subclasses
+    `QuicConnectionProtocol` and so is asyncio only:
+    https://github.com/aiortc/aioquic/blob/main/examples/httpx_client.py
+
+    The request handling here follows that example. What differs is underneath it:
+    aioquic's `QuicConnection` is sans-io, so this drives it over an anyio datagram
+    socket exactly as `QuicProtocol` does server-side, which is what lets these tests
+    run on trio as well as asyncio. The socket comes from `wrap_datagram_socket()`
+    rather than anyio directly, so the client gets the same win32 asyncio treatment
+    the server does - anyio's UDP `aclose()` otherwise hangs on the proactor loop.
+    """
+
+    def __init__(
+        self, quic: QuicConnection, sock: DatagramSocket, address: tuple[str, int]
+    ) -> None:
+        self._quic = quic
+        self._socket = sock
+        self._address = address
+        self._http: H3Connection | None = None
+        self._read_queue: dict[int, list[H3Event]] = {}
+        self._read_ready: dict[int, anyio.Event] = {}
+        self._connected = anyio.Event()
+        self._terminated = anyio.Event()
+        self._send_lock = anyio.Lock()
+
+    @classmethod
+    @asynccontextmanager
+    async def connect(cls, host: str, port: int, certs: TLSCerts) -> AsyncIterator[_H3Transport]:
+        """Open a QUIC connection, yielding a transport once the handshake lands."""
+        configuration = QuicConfiguration(is_client=True, alpn_protocols=H3_ALPN)
+        # Verify the chain rather than turning verification off: the handshake is
+        # part of what these tests are covering
+        configuration.load_verify_locations(cafile=str(certs.cafile))
+        configuration.server_name = certs.hostname
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind((HOST, 0))
+        sock.setblocking(False)  # noqa: FBT003
+        datagram_socket = await wrap_datagram_socket(sock)
+
+        quic = QuicConnection(configuration=configuration)
+        self = cls(quic, datagram_socket, (host, port))
+        try:
+            async with anyio.create_task_group() as task_group:
+                quic.connect(self._address, now=anyio.current_time())
+                task_group.start_soon(self._receive_loop)
+                task_group.start_soon(self._timer_loop)
+                await self._transmit()
+
+                with anyio.fail_after(10):
+                    await self._connected.wait()
+                self._http = H3Connection(quic)
+                await self._transmit()
+
+                try:
+                    yield self
+                finally:
+                    quic.close()
+                    with anyio.CancelScope(shield=True):
+                        await self._transmit()
+                    task_group.cancel_scope.cancel()
+        finally:
+            await datagram_socket.aclose()
+
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+        assert self._http is not None
         stream_id = self._quic.get_next_available_stream_id()
+        self._read_queue[stream_id] = []
+        self._read_ready[stream_id] = anyio.Event()
+
         self._http.send_headers(
-            stream_id,
-            [
-                (b":method", b"GET"),
-                (b":scheme", b"https"),
-                (b":authority", BIND.encode()),
-                (b":path", path.encode()),
+            stream_id=stream_id,
+            headers=[
+                (b":method", request.method.encode()),
+                (b":scheme", request.url.raw_scheme),
+                (b":authority", request.url.netloc),
+                (b":path", request.url.raw_path),
+                *[
+                    (name.lower(), value)
+                    for (name, value) in request.headers.raw
+                    if name.lower() not in {b"connection", b"host"}
+                ],
             ],
-            end_stream=True,
         )
-        self.transmit()
-        await self._done
-        return self._headers, bytes(self._body)
+        async for data in request.stream:  # type: ignore[union-attr]
+            self._http.send_data(stream_id=stream_id, data=data, end_stream=False)
+        self._http.send_data(stream_id=stream_id, data=b"", end_stream=True)
+        await self._transmit()
+
+        status_code, headers, stream_ended = await self._receive_response(stream_id)
+        return httpx2.Response(
+            status_code,
+            headers=headers,
+            stream=_H3ResponseStream(self._receive_response_data(stream_id, stream_ended)),
+            extensions={"http_version": b"HTTP/3"},
+        )
+
+    async def _receive_loop(self) -> None:
+        while True:
+            try:
+                data, address = await self._socket.receive()
+            except (anyio.ClosedResourceError, anyio.EndOfStream):
+                return
+            self._quic.receive_datagram(data, address, now=anyio.current_time())
+            await self._process()
+
+    async def _timer_loop(self) -> None:
+        while True:
+            await anyio.sleep(TIMER_INTERVAL)
+            timer = self._quic.get_timer()
+            if timer is not None and anyio.current_time() >= timer:
+                self._quic.handle_timer(now=anyio.current_time())
+                await self._process()
+
+    async def _process(self) -> None:
+        """Drain QUIC events into the HTTP layer, then flush whatever they produced."""
+        event = self._quic.next_event()
+        while event is not None:
+            if isinstance(event, HandshakeCompleted):
+                self._connected.set()
+            elif isinstance(event, ConnectionTerminated):
+                self._terminated.set()
+                for ready in self._read_ready.values():
+                    ready.set()
+
+            if self._http is not None:
+                for h3_event in self._http.handle_event(event):
+                    self._queue_http_event(h3_event)
+
+            event = self._quic.next_event()
+
+        await self._transmit()
+
+    def _queue_http_event(self, event: H3Event) -> None:
+        if isinstance(event, (HeadersReceived, DataReceived)):
+            queue = self._read_queue.get(event.stream_id)
+            if queue is not None:
+                queue.append(event)
+                self._read_ready[event.stream_id].set()
+
+    async def _transmit(self) -> None:
+        # Sends come from the read loop and the timer as well as from requests, and
+        # anyio permits one writer to a socket at a time
+        async with self._send_lock:
+            for data, address in self._quic.datagrams_to_send(now=anyio.current_time()):
+                await self._socket.sendto(data, address[0], address[1])
+
+    async def _receive_response(self, stream_id: int) -> tuple[int, list, bool]:
+        while True:
+            event = await self._wait_for_http_event(stream_id)
+            if isinstance(event, HeadersReceived):
+                break
+
+        headers = []
+        status_code = 0
+        for header, value in event.headers:
+            if header == b":status":
+                status_code = int(value.decode())
+            else:
+                headers.append((header, value))
+        return status_code, headers, event.stream_ended
+
+    async def _receive_response_data(
+        self,
+        stream_id: int,
+        stream_ended: bool,  # noqa: FBT001
+    ) -> AsyncIterator[bytes]:
+        while not stream_ended:
+            event = await self._wait_for_http_event(stream_id)
+            if isinstance(event, (DataReceived, HeadersReceived)):
+                stream_ended = event.stream_ended
+            if isinstance(event, DataReceived):
+                yield event.data
+
+    async def _wait_for_http_event(self, stream_id: int) -> H3Event:
+        while not self._read_queue[stream_id]:
+            if self._terminated.is_set():
+                msg = "connection terminated before the response completed"
+                raise AssertionError(msg)
+            await self._read_ready[stream_id].wait()
+        event = self._read_queue[stream_id].pop(0)
+        if not self._read_queue[stream_id]:
+            self._read_ready[stream_id] = anyio.Event()
+        return event
 
 
-@pytest.mark.anyio
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])  # aioquic's client is asyncio only
-async def test_h3_request() -> None:
+@asynccontextmanager
+async def _serving(certs: TLSCerts) -> AsyncIterator[None]:
+    """Run the worker on the QUIC bind, shutting it down on the way out."""
     config = Config()
     config.bind = [BIND]
     config.quic_bind = [BIND]
-    config.certfile = str(ASSETS / "cert.pem")
-    config.keyfile = str(ASSETS / "key.pem")
+    config.certfile = str(certs.certfile)
+    config.keyfile = str(certs.keyfile)
     config.accesslog = "-"
     config.errorlog = "-"
 
-    client_config = QuicConfiguration(is_client=True, alpn_protocols=H3_ALPN)
-    client_config.verify_mode = ssl.CERT_NONE
-
     shutdown = anyio.Event()
-    async with anyio.create_task_group() as tg:
-        binds = await tg.start(
+    async with anyio.create_task_group() as task_group:
+        binds = await task_group.start(
             lambda *, task_status: anycorn.serve(
                 app, config, shutdown_trigger=shutdown.wait, task_status=task_status
             )
         )
-        assert any("4433" in bind for bind in binds)
+        assert any(str(PORT) in bind for bind in binds)
+        try:
+            yield
+        finally:
+            shutdown.set()
 
-        async with connect(
-            "127.0.0.1", 4433, configuration=client_config, create_protocol=_H3Client
-        ) as connection:
-            client = cast("_H3Client", connection)
-            with anyio.fail_after(10):
-                headers, body = await client.get("/")
 
-        shutdown.set()
+@pytest.mark.anyio
+async def test_h3_request(tls_certs: TLSCerts) -> None:
+    async with (
+        _serving(tls_certs),
+        _H3Transport.connect(HOST, PORT, tls_certs) as transport,
+        httpx2.AsyncClient(transport=transport) as client,
+    ):
+        with anyio.fail_after(10):
+            response = await client.get(f"https://{BIND}/")
 
-    assert dict(headers)[b":status"] == b"200"
-    assert body == b"Hello, h3!"
+    assert response.status_code == 200  # noqa: PLR2004
+    assert response.text == "Hello, h3!"
+    assert response.headers["content-type"] == "text/plain"
+    assert response.extensions["http_version"] == b"HTTP/3"

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -28,8 +28,6 @@ if TYPE_CHECKING:
     from tests.conftest import TLSCerts
 
 HOST = "127.0.0.1"
-PORT = 4433
-BIND = f"{HOST}:{PORT}"
 # QUIC drives loss recovery off timers, so one has to be serviced even when no
 # datagram arrives. Polling is coarser than the server's restartable timer task but
 # far harder to get wrong, and on loopback the difference does not show.
@@ -247,11 +245,11 @@ class _H3Transport(httpx2.AsyncBaseTransport):
 
 
 @asynccontextmanager
-async def _serving(certs: TLSCerts) -> AsyncIterator[None]:
-    """Run the worker on the QUIC bind, shutting it down on the way out."""
+async def _serving(certs: TLSCerts, tcp_port: int, quic_port: int) -> AsyncIterator[None]:
+    """Run the worker on the given ports, shutting it down on the way out."""
     config = Config()
-    config.bind = [BIND]
-    config.quic_bind = [BIND]
+    config.bind = [f"{HOST}:{tcp_port}"]
+    config.quic_bind = [f"{HOST}:{quic_port}"]
     config.certfile = str(certs.certfile)
     config.keyfile = str(certs.keyfile)
     config.accesslog = "-"
@@ -259,12 +257,11 @@ async def _serving(certs: TLSCerts) -> AsyncIterator[None]:
 
     shutdown = anyio.Event()
     async with anyio.create_task_group() as task_group:
-        binds = await task_group.start(
+        await task_group.start(
             lambda *, task_status: anycorn.serve(
                 app, config, shutdown_trigger=shutdown.wait, task_status=task_status
             )
         )
-        assert any(str(PORT) in bind for bind in binds)
         try:
             yield
         finally:
@@ -272,14 +269,14 @@ async def _serving(certs: TLSCerts) -> AsyncIterator[None]:
 
 
 @pytest.mark.anyio
-async def test_h3_request(tls_certs: TLSCerts) -> None:
+async def test_h3_request(tls_certs: TLSCerts, free_tcp_port: int, free_udp_port: int) -> None:
     async with (
-        _serving(tls_certs),
-        _H3Transport.connect(HOST, PORT, tls_certs) as transport,
+        _serving(tls_certs, free_tcp_port, free_udp_port),
+        _H3Transport.connect(HOST, free_udp_port, tls_certs) as transport,
         httpx2.AsyncClient(transport=transport) as client,
     ):
         with anyio.fail_after(10):
-            response = await client.get(f"https://{BIND}/")
+            response = await client.get(f"https://{HOST}:{free_udp_port}/")
 
     assert response.status_code == 200  # noqa: PLR2004
     assert response.text == "Hello, h3!"

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -93,7 +93,9 @@ class _H3Transport(httpx2.AsyncBaseTransport):
 
     @classmethod
     @asynccontextmanager
-    async def connect(cls, host: str, port: int, certs: TLSCerts) -> AsyncIterator[_H3Transport]:
+    async def connect(
+        cls, host: str, port: int, certs: TLSCerts, local_port: int = 0
+    ) -> AsyncIterator[_H3Transport]:
         """Open a QUIC connection, yielding a transport once the handshake lands."""
         configuration = QuicConfiguration(is_client=True, alpn_protocols=H3_ALPN)
         # Verify the chain rather than turning verification off: the handshake is
@@ -102,7 +104,7 @@ class _H3Transport(httpx2.AsyncBaseTransport):
         configuration.server_name = certs.hostname
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.bind((HOST, 0))
+        sock.bind((HOST, local_port))
         sock.setblocking(False)  # noqa: FBT003
         datagram_socket = await wrap_datagram_socket(sock)
 
@@ -364,3 +366,61 @@ async def test_concurrent_requests_share_one_connection(
     assert clients == [transport.local_address] * CONCURRENT_REQUESTS
     # And a single handshake, so that flow carried one connection rather than three
     assert transport.handshakes == 1
+
+
+def _state_app(seen: list[tuple[str, dict, int, tuple[str, int] | None]]) -> Callable:
+    """Return an app that records the state it was handed, then writes to it."""
+
+    async def _app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
+        state = scope["state"]
+        seen.append((scope["path"], dict(state), id(state), scope["client"]))
+        state["secret"] = scope["path"]
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    return _app
+
+
+@pytest.mark.anyio
+async def test_state_is_not_shared_between_connections(
+    tls_certs: TLSCerts,
+    free_tcp_port: int,
+    free_udp_port: int,
+    free_udp_port_factory: Callable[[], int],
+) -> None:
+    """ASGI state is per connection, so one client cannot read the last one's.
+
+    Both connections are made from the same client port, so the server sees one
+    address throughout. Anything keyed on where the datagrams came from - a copy per
+    UDP socket, or per peer - would hand the second connection the first's namespace;
+    only keying on the connection itself keeps them apart.
+    """
+    seen: list[tuple[str, dict, int, tuple[str, int] | None]] = []
+    client_port = free_udp_port_factory()
+
+    async with _serving(tls_certs, free_tcp_port, free_udp_port, _state_app(seen)):
+        for path in ("/first", "/second"):
+            async with (
+                _H3Transport.connect(
+                    HOST, free_udp_port, tls_certs, local_port=client_port
+                ) as transport,
+                httpx2.AsyncClient(transport=transport) as client,
+            ):
+                assert transport.local_address == (HOST, client_port)
+                with anyio.fail_after(10):
+                    response = await client.get(f"https://{HOST}:{free_udp_port}{path}")
+                assert response.status_code == 200  # noqa: PLR2004
+
+    assert [path for path, _, _, _ in seen] == ["/first", "/second"]
+    # The same peer both times, so the server had no address to tell them apart by
+    assert [client for _, _, _, client in seen] == [(HOST, client_port)] * 2
+    # And still neither the first's contents nor its namespace
+    assert [state for _, state, _, _ in seen] == [{}, {}]
+    first_id, second_id = (ident for _, _, ident, _ in seen)
+    assert first_id != second_id

--- a/tests/test_datagram.py
+++ b/tests/test_datagram.py
@@ -1,0 +1,79 @@
+"""Tests for the datagram sockets shared by statsd and the QUIC server."""
+
+from __future__ import annotations
+
+import socket
+import sys
+
+import pytest
+
+from anycorn.datagram import _AnyioDatagramSocket, _AsyncioDatagramSocket, wrap_datagram_socket
+
+
+def _bound_socket() -> socket.socket:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.setblocking(False)  # noqa: FBT003
+    return sock
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_asyncio_socket_releases_socket() -> None:
+    """The Windows implementation must neither leak its socket nor hang after a send.
+
+    Only reached on Windows in production, so exercise it everywhere: on the proactor
+    loop `transport.close()` alone leaves the socket open whilst a write is in flight.
+    """
+    sock = await _AsyncioDatagramSocket.connect("127.0.0.1", 9125)
+    await sock.send(b"anycorn.test:1|c")
+    await sock.aclose()
+    assert sock.socket.fileno() == -1
+
+
+@pytest.mark.anyio
+async def test_anyio_socket_releases_socket(anyio_backend_name: str) -> None:
+    """The implementation used on every platform other than Windows."""
+    if sys.platform == "win32" and anyio_backend_name == "asyncio":
+        # This is the combination the datagram module avoids: anyio's aclose() waits for
+        # a connection_lost() the proactor loop never delivers, so it would hang here
+        pytest.skip("anyio's UDP aclose() hangs on the proactor event loop")
+
+    sock = await _AnyioDatagramSocket.connect("127.0.0.1", 9125)
+    await sock.send(b"anycorn.test:1|c")
+    await sock.aclose()
+    assert sock.socket.fileno() == -1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_asyncio_socket_roundtrip() -> None:
+    """Datagrams sent to an adopted socket come back out of receive()."""
+    server = await _AsyncioDatagramSocket.from_socket(_bound_socket())
+    host, port = server.socket.getsockname()
+    client = await _AsyncioDatagramSocket.connect(host, port)
+
+    await client.send(b"ping")
+    data, address = await server.receive()
+    assert data == b"ping"
+
+    await server.sendto(b"pong", address[0], address[1])
+    echoed, _ = await client.receive()
+    assert echoed == b"pong"
+
+    await client.aclose()
+    await server.aclose()
+
+
+@pytest.mark.anyio
+async def test_wrap_datagram_socket_takes_ownership(anyio_backend_name: str) -> None:
+    """Whichever implementation is chosen, closing it closes the adopted socket."""
+    if sys.platform == "win32" and anyio_backend_name == "asyncio":
+        pytest.skip("anyio's UDP aclose() hangs on the proactor event loop")
+
+    raw = _bound_socket()
+    sock = await wrap_datagram_socket(raw)
+    assert sock.socket.fileno() == raw.fileno()
+
+    await sock.aclose()
+    assert raw.fileno() == -1

--- a/tests/test_h2_multiplexing.py
+++ b/tests/test_h2_multiplexing.py
@@ -1,4 +1,4 @@
-"""Tests that HTTP/2 carries concurrent requests on a single connection."""
+"""Tests that HTTP/2 carries concurrent requests at once, rather than in turn."""
 
 from __future__ import annotations
 
@@ -29,7 +29,6 @@ class _Rendezvous:
     def __init__(self, expected: int) -> None:
         self.expected = expected
         self.arrived: list[str] = []
-        self.states: list[int] = []
         self.released = anyio.Event()
 
     async def __call__(
@@ -38,9 +37,6 @@ class _Rendezvous:
         assert scope["type"] == "http"
         assert scope["http_version"] == "2"
         self.arrived.append(scope["path"])
-        # Identity, not contents: ASGI copies this per connection, so one namespace
-        # across every request means one connection carried them
-        self.states.append(id(scope["state"]))
         if len(self.arrived) >= self.expected:
             self.released.set()
 
@@ -81,8 +77,13 @@ async def _read_responses(
 
 
 @pytest.mark.anyio
-async def test_concurrent_requests_share_one_connection() -> None:
-    """HTTP/2 multiplexes concurrent requests rather than taking them in turn."""
+async def test_concurrent_requests_are_multiplexed() -> None:
+    """The server carries concurrent HTTP/2 requests at once, on one connection.
+
+    The single connection is the harness's doing - there is one stream pair - so it is
+    the fixed condition rather than the finding. What is being tested is that three
+    requests are carried over it simultaneously instead of one at a time.
+    """
     app = _Rendezvous(CONCURRENT_REQUESTS)
 
     async with serve_in_memory(app, alpn_protocol="h2") as client_stream:
@@ -115,5 +116,3 @@ async def test_concurrent_requests_share_one_connection() -> None:
     # Each answered, and answered as itself rather than as a sibling
     assert bodies == {stream_id: path.encode() for stream_id, path in paths.items()}
     assert sorted(app.arrived) == sorted(paths.values())
-    # One state namespace, so one connection served all three
-    assert len(set(app.states)) == 1

--- a/tests/test_h2_multiplexing.py
+++ b/tests/test_h2_multiplexing.py
@@ -1,0 +1,119 @@
+"""Tests that HTTP/2 carries concurrent requests on a single connection."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import anyio
+import h2.connection
+import h2.events
+import pytest
+
+from .helpers import serve_in_memory
+
+if TYPE_CHECKING:
+    from anycorn.typing import ASGIReceiveCallable, ASGISendCallable, Scope
+
+CONCURRENT_REQUESTS = 3
+OK = 200
+
+
+class _Rendezvous:
+    """An ASGI app that answers nothing until every request has arrived.
+
+    A response arriving at all is then evidence the server is carrying them at once.
+    Were it taking one at a time, the first would sit waiting on siblings that cannot
+    be read yet, and the caller would time out rather than pass.
+    """
+
+    def __init__(self, expected: int) -> None:
+        self.expected = expected
+        self.arrived: list[str] = []
+        self.states: list[int] = []
+        self.released = anyio.Event()
+
+    async def __call__(
+        self, scope: Scope, _receive: ASGIReceiveCallable, send: ASGISendCallable
+    ) -> None:
+        assert scope["type"] == "http"
+        assert scope["http_version"] == "2"
+        self.arrived.append(scope["path"])
+        # Identity, not contents: ASGI copies this per connection, so one namespace
+        # across every request means one connection carried them
+        self.states.append(id(scope["state"]))
+        if len(self.arrived) >= self.expected:
+            self.released.set()
+
+        await self.released.wait()
+        body = scope["path"].encode()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-length", b"%d" % len(body))],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+async def _read_responses(
+    client: h2.connection.H2Connection,
+    client_stream: Any,  # noqa: ANN401
+    expected: int,
+) -> dict[int, bytes]:
+    """Collect one complete response per stream, until *expected* have ended."""
+    bodies: dict[int, bytearray] = {}
+    ended: set[int] = set()
+    while len(ended) < expected:
+        data = await client_stream.receive_some(2**16)
+        assert data != b"", "connection closed before every response arrived"
+        for event in client.receive_data(data):
+            if isinstance(event, h2.events.DataReceived):
+                bodies.setdefault(event.stream_id, bytearray()).extend(event.data)
+                client.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+            elif isinstance(event, h2.events.ResponseReceived):
+                assert dict(event.headers)[b":status"] == b"%d" % OK
+            elif isinstance(event, h2.events.StreamEnded):
+                ended.add(event.stream_id)
+        await client_stream.send_all(client.data_to_send())
+
+    return {stream_id: bytes(body) for stream_id, body in bodies.items()}
+
+
+@pytest.mark.anyio
+async def test_concurrent_requests_share_one_connection() -> None:
+    """HTTP/2 multiplexes concurrent requests rather than taking them in turn."""
+    app = _Rendezvous(CONCURRENT_REQUESTS)
+
+    async with serve_in_memory(app, alpn_protocol="h2") as client_stream:
+        client = h2.connection.H2Connection()
+        client.initiate_connection()
+        await client_stream.send_all(client.data_to_send())
+
+        paths = {}
+        for index in range(CONCURRENT_REQUESTS):
+            path = f"/{index}"
+            stream_id = client.get_next_available_stream_id()
+            client.send_headers(
+                stream_id,
+                [
+                    (b":method", b"GET"),
+                    (b":path", path.encode()),
+                    (b":authority", b"anycorn"),
+                    (b":scheme", b"https"),
+                ],
+                end_stream=True,
+            )
+            paths[stream_id] = path
+        # Every request goes out before any response is read, so the server has all
+        # three in hand at once
+        await client_stream.send_all(client.data_to_send())
+
+        with anyio.fail_after(5):
+            bodies = await _read_responses(client, client_stream, CONCURRENT_REQUESTS)
+
+    # Each answered, and answered as itself rather than as a sibling
+    assert bodies == {stream_id: path.encode() for stream_id, path in paths.items()}
+    assert sorted(app.arrived) == sorted(paths.values())
+    # One state namespace, so one connection served all three
+    assert len(set(app.states)) == 1

--- a/tests/test_h3_optional.py
+++ b/tests/test_h3_optional.py
@@ -1,0 +1,66 @@
+"""Anycorn must import and serve without the optional h3 dependency installed."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+# Run in a subprocess so aioquic can be hidden before anycorn is imported at all
+_SCRIPT = """
+import sys
+
+
+class _Blocker:
+    def find_spec(self, name, path=None, target=None):
+        if name == "aioquic" or name.startswith("aioquic."):
+            msg = f"hidden for this test: {name}"
+            raise ImportError(msg)
+        return None
+
+
+sys.meta_path.insert(0, _Blocker())
+for name in [n for n in sys.modules if n.startswith("aioquic")]:
+    del sys.modules[name]
+
+import anyio
+
+import anycorn
+from anycorn.config import Config
+
+
+async def app(scope, receive, send):
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b""})
+
+
+async def main():
+    config = Config()
+    config.bind = ["127.0.0.1:0"]
+    shutdown = anyio.Event()
+    async with anyio.create_task_group() as tg:
+        binds = await tg.start(
+            lambda *, task_status: anycorn.serve(
+                app, config, shutdown_trigger=shutdown.wait, task_status=task_status
+            )
+        )
+        assert binds, "expected a bind"
+        shutdown.set()
+
+    print("SERVED")
+
+
+anyio.run(main)
+"""
+
+
+def test_serves_without_aioquic() -> None:
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "SERVED" in result.stdout
+    assert "aioquic" not in result.stderr

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,54 @@
+"""Tests for worker startup and socket lifecycle."""
+
+from __future__ import annotations
+
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+
+from anycorn.config import Config
+from anycorn.run import worker_serve
+from anycorn.utils import wrap_app
+
+ASSETS = Path(__file__).parent / "assets"
+
+
+async def app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
+    assert scope["type"] == "http"
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b""})
+
+
+@pytest.mark.anyio
+async def test_worker_serve_closes_quic_sockets() -> None:
+    """QUIC sockets are opened by create_sockets(), so the worker must close them."""
+    config = Config()
+    config.bind = ["127.0.0.1:0"]
+    config.quic_bind = ["127.0.0.1:0"]
+    config.certfile = str(ASSETS / "cert.pem")
+    config.keyfile = str(ASSETS / "key.pem")
+
+    sockets = config.create_sockets()
+    quic_sockets = list(sockets.quic_sockets)
+    assert quic_sockets, "expected create_sockets to bind a QUIC socket"
+    for sock in sockets.secure_sockets:
+        sock.listen(config.backlog)
+
+    shutdown = anyio.Event()
+    async with anyio.create_task_group() as tg:
+        binds = await tg.start(
+            partial(
+                worker_serve,
+                wrap_app(app, config.wsgi_max_body_size, None),
+                config,
+                sockets=sockets,
+                shutdown_trigger=shutdown.wait,
+            )
+        )
+        assert len(binds) == len(sockets.secure_sockets) + len(quic_sockets)
+        shutdown.set()
+
+    assert [sock.fileno() for sock in quic_sockets] == [-1] * len(quic_sockets)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import socket
 from functools import partial
+from pickle import PicklingError
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 
 import anyio
 import pytest
 
+import anycorn.run
 from anycorn.config import Config
 from anycorn.datagram import wrap_datagram_socket
 from anycorn.events import RawData
-from anycorn.run import worker_serve
+from anycorn.run import run, worker_serve
 from anycorn.udp_server import UDPServer
 from anycorn.utils import wrap_app
 from anycorn.worker_context import WorkerContext
@@ -83,3 +85,61 @@ async def test_udp_server_serialises_concurrent_sends() -> None:
                 )
     finally:
         await datagram_socket.aclose()
+
+
+def test_run_closes_sockets_when_it_raises(
+    tls_certs: TLSCerts, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The parent's sockets are closed however run() exits, not only when it finishes."""
+    config = Config()
+    config.bind = ["127.0.0.1:0"]
+    config.quic_bind = ["127.0.0.1:0"]
+    config.certfile = str(tls_certs.certfile)
+    config.keyfile = str(tls_certs.keyfile)
+    sockets = config.create_sockets()
+    monkeypatch.setattr(config, "create_sockets", lambda: sockets)
+
+    # The earliest thing run() refuses to do, so it raises with the sockets already open
+    config.use_reloader = True
+    config.workers = 0
+    with pytest.raises(RuntimeError, match="Cannot reload without workers"):
+        run(config)
+
+    opened = [*sockets.secure_sockets, *sockets.insecure_sockets, *sockets.quic_sockets]
+    assert opened, "expected create_sockets to bind something"
+    assert [sock.fileno() for sock in opened] == [-1] * len(opened)
+
+
+def test_run_terminates_workers_when_it_raises(
+    tls_certs: TLSCerts, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run that fails partway signals its workers rather than orphaning them."""
+    config = Config()
+    config.bind = ["127.0.0.1:0"]
+    config.certfile = str(tls_certs.certfile)
+    config.keyfile = str(tls_certs.keyfile)
+    sockets = config.create_sockets()
+    monkeypatch.setattr(config, "create_sockets", lambda: sockets)
+    config.workers = 2
+
+    terminated: list[object] = []
+
+    class _Process:
+        sentinel = None
+        exitcode = None
+
+        def terminate(self) -> None:
+            terminated.append(self)
+
+    def _spawn_then_fail(processes: list, *_args: object, **_kwargs: object) -> None:
+        # One worker up, the next refusing - the shape that used to walk past the
+        # terminate loop entirely
+        processes.append(_Process())
+        raise PicklingError
+
+    monkeypatch.setattr(anycorn.run, "_populate", _spawn_then_fail)
+
+    with pytest.raises(PicklingError):
+        run(config)
+
+    assert len(terminated) == 1

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+import socket
 from functools import partial
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock
 
 import anyio
 import pytest
 
 from anycorn.config import Config
+from anycorn.datagram import wrap_datagram_socket
+from anycorn.events import RawData
 from anycorn.run import worker_serve
+from anycorn.udp_server import UDPServer
 from anycorn.utils import wrap_app
+from anycorn.worker_context import WorkerContext
 
 ASSETS = Path(__file__).parent / "assets"
 
@@ -52,3 +58,28 @@ async def test_worker_serve_closes_quic_sockets() -> None:
         shutdown.set()
 
     assert [sock.fileno() for sock in quic_sockets] == [-1] * len(quic_sockets)
+
+
+@pytest.mark.anyio
+async def test_udp_server_serialises_concurrent_sends() -> None:
+    """QUIC sends from several tasks at once must not collide on the socket.
+
+    anyio guards a socket against concurrent writers rather than interleaving them,
+    so the timer and stream tasks sending alongside the read loop would otherwise
+    raise `BusyResourceError` at whichever one lost the race.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.setblocking(False)  # noqa: FBT003
+    datagram_socket = await wrap_datagram_socket(sock)
+    server = UDPServer(AsyncMock(), Config(), WorkerContext(None), {}, datagram_socket)
+
+    try:
+        async with anyio.create_task_group() as task_group:
+            for _ in range(20):
+                task_group.start_soon(
+                    server.protocol_send,
+                    RawData(data=b"x" * 1024, address=("127.0.0.1", 9999)),
+                )
+    finally:
+        await datagram_socket.aclose()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import socket
 from functools import partial
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 
 import anyio
@@ -19,7 +18,8 @@ from anycorn.udp_server import UDPServer
 from anycorn.utils import wrap_app
 from anycorn.worker_context import WorkerContext
 
-ASSETS = Path(__file__).parent / "assets"
+if TYPE_CHECKING:
+    from tests.conftest import TLSCerts
 
 
 async def app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
@@ -29,13 +29,13 @@ async def app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
 
 
 @pytest.mark.anyio
-async def test_worker_serve_closes_quic_sockets() -> None:
+async def test_worker_serve_closes_quic_sockets(tls_certs: TLSCerts) -> None:
     """QUIC sockets are opened by create_sockets(), so the worker must close them."""
     config = Config()
     config.bind = ["127.0.0.1:0"]
     config.quic_bind = ["127.0.0.1:0"]
-    config.certfile = str(ASSETS / "cert.pem")
-    config.keyfile = str(ASSETS / "key.pem")
+    config.certfile = str(tls_certs.certfile)
+    config.keyfile = str(tls_certs.keyfile)
 
     sockets = config.create_sockets()
     quic_sockets = list(sockets.quic_sockets)

--- a/tests/test_state_isolation.py
+++ b/tests/test_state_isolation.py
@@ -1,0 +1,117 @@
+"""Tests that ASGI state is per request rather than per connection.
+
+ASGI has the server pass "a shallow copy of the namespace ... into each subsequent
+request/response call", so two requests sharing a connection must not share what they
+put there. Multiplexed protocols make that easy to get wrong: h2 and h3 carry many
+requests over one connection, and the connection is the obvious place to copy once.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import h2.connection
+import h2.events
+import h11
+import pytest
+
+from .helpers import serve_in_memory
+
+if TYPE_CHECKING:
+    from anycorn.typing import ASGIReceiveCallable, ASGISendCallable, HTTPScope
+
+REQUESTS = 2
+
+
+class _StateRecorder:
+    """Records the state it is handed, then writes to it."""
+
+    def __init__(self) -> None:
+        self.seen: list[dict] = []
+        # The namespaces themselves, not their ids: a freed dict's address can be
+        # handed straight back to the next one, so ids only tell objects apart
+        # whilst both are alive
+        self.states: list[dict] = []
+
+    async def __call__(
+        self, scope: HTTPScope, _receive: ASGIReceiveCallable, send: ASGISendCallable
+    ) -> None:
+        state = scope["state"]
+        self.seen.append(dict(state))
+        self.states.append(state)
+        state["secret"] = scope["path"]
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-length", b"2")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+
+@pytest.mark.anyio
+async def test_http1_requests_do_not_share_state() -> None:
+    """Two requests on one kept-alive connection each get their own namespace."""
+    app = _StateRecorder()
+
+    async with serve_in_memory(app) as client_stream:
+        client = h11.Connection(h11.CLIENT)
+        for index in range(REQUESTS):
+            if index:
+                client.start_next_cycle()
+            request = h11.Request(method="GET", target=f"/{index}", headers=[(b"host", b"anycorn")])
+            await client_stream.send_all(client.send(request))
+            await client_stream.send_all(client.send(h11.EndOfMessage()))
+            while True:
+                event = client.next_event()
+                if event is h11.NEED_DATA:
+                    client.receive_data(await client_stream.receive_some(2**16))
+                elif isinstance(event, h11.EndOfMessage):
+                    break
+
+    assert app.seen == [{}, {}]
+    first, second = app.states
+    assert first is not second
+
+
+@pytest.mark.anyio
+async def test_http2_requests_do_not_share_state() -> None:
+    """Two requests multiplexed on one h2 connection each get their own namespace."""
+    app = _StateRecorder()
+
+    async with serve_in_memory(app, alpn_protocol="h2") as client_stream:
+        client = h2.connection.H2Connection()
+        client.initiate_connection()
+        await client_stream.send_all(client.data_to_send())
+
+        for index in range(REQUESTS):
+            stream_id = client.get_next_available_stream_id()
+            client.send_headers(
+                stream_id,
+                [
+                    (b":method", b"GET"),
+                    (b":path", f"/{index}".encode()),
+                    (b":authority", b"anycorn"),
+                    (b":scheme", b"https"),
+                ],
+                end_stream=True,
+            )
+        await client_stream.send_all(client.data_to_send())
+
+        ended: set[int] = set()
+        while len(ended) < REQUESTS:
+            data = await client_stream.receive_some(2**16)
+            assert data != b"", "connection closed before both responses arrived"
+            for event in client.receive_data(data):
+                if isinstance(event, h2.events.DataReceived):
+                    client.acknowledge_received_data(event.flow_controlled_length, event.stream_id)
+                elif isinstance(event, h2.events.StreamEnded):
+                    ended.add(event.stream_id)
+            await client_stream.send_all(client.data_to_send())
+
+    # Neither request saw what the other stored, and neither shared its namespace
+    assert app.seen == [{}, {}]
+    first, second = app.states
+    assert first is not second

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -1,16 +1,15 @@
-"""Tests for the statsd logger's UDP senders."""
+"""Tests for the statsd logger."""
 
 from __future__ import annotations
 
 import socket
-import sys
 
 import anyio
 import pytest
 from anyio.abc import SocketAttribute
 
 from anycorn.config import Config
-from anycorn.statsd import StatsdLogger, _AnyioSender, _AsyncioSender
+from anycorn.statsd import StatsdLogger
 
 
 def _unused_udp_port() -> int:
@@ -55,34 +54,6 @@ async def test_metrics_survive_a_daemon_that_is_not_listening() -> None:
             await anyio.sleep(0.01)
     finally:
         await logger.aclose()
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
-async def test_asyncio_sender_releases_socket() -> None:
-    """The Windows sender must neither leak its socket nor hang after a send.
-
-    Only reached on Windows in production, so exercise it everywhere: on the proactor
-    loop `transport.close()` alone leaves the socket open whilst a write is in flight.
-    """
-    sender = await _AsyncioSender.create("127.0.0.1", 9125)
-    await sender.send(b"anycorn.test:1|c")
-    await sender.aclose()
-    assert sender.socket.fileno() == -1
-
-
-@pytest.mark.anyio
-async def test_anyio_sender_releases_socket(anyio_backend_name: str) -> None:
-    """The sender used on every platform other than Windows."""
-    if sys.platform == "win32" and anyio_backend_name == "asyncio":
-        # This is the combination StatsdLogger avoids: anyio's aclose() waits for a
-        # connection_lost() the proactor loop never delivers, so it would hang here
-        pytest.skip("anyio's UDP aclose() hangs on the proactor event loop")
-
-    sender = await _AnyioSender.create("127.0.0.1", 9125)
-    await sender.send(b"anycorn.test:1|c")
-    await sender.aclose()
-    assert sender.socket.fileno() == -1
 
 
 @pytest.mark.anyio

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "trio" },
+    { name = "trustme" },
     { name = "ty" },
 ]
 test = [
@@ -69,6 +70,7 @@ test = [
     { name = "mock" },
     { name = "pytest" },
     { name = "trio" },
+    { name = "trustme" },
 ]
 
 [package.metadata]
@@ -96,6 +98,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.6" },
     { name = "trio" },
+    { name = "trustme" },
     { name = "ty", specifier = ">=0.0.22" },
 ]
 test = [
@@ -104,6 +107,7 @@ test = [
     { name = "mock" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "trio" },
+    { name = "trustme" },
 ]
 
 [[package]]
@@ -714,6 +718,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/8f/c6e36dd11201e2a565977d8b13f0b027ba4593c1a80bed5185489178e257/trio-0.31.0.tar.gz", hash = "sha256:f71d551ccaa79d0cb73017a33ef3264fde8335728eb4c6391451fe5d253a9d5b", size = 605825, upload-time = "2025-09-09T15:17:15.242Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/5b/94237a3485620dbff9741df02ff6d8acaa5fdec67d81ab3f62e4d8511bf7/trio-0.31.0-py3-none-any.whl", hash = "sha256:b5d14cd6293d79298b49c3485ffd9c07e3ce03a6da8c7dfbe0cb3dd7dc9a4774", size = 512679, upload-time = "2025-09-09T15:17:13.821Z" },
+]
+
+[[package]]
+name = "trustme"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/c5/931476f4cf1cd9e736f32651005078061a50dc164a2569fb874e00eb2786/trustme-1.2.1.tar.gz", hash = "sha256:6528ba2bbc7f2db41f33825c8dd13e3e3eb9d334ba0f909713c8c3139f4ae47f", size = 26844, upload-time = "2025-01-02T01:55:32.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/f3/c34dbabf6da5eda56fe923226769d40e11806952cd7f46655dd06e10f018/trustme-1.2.1-py3-none-any.whl", hash = "sha256:d768e5fc57c86dfc5ec9365102e9b092541cd6954b35d8c1eea01a84f35a762a", size = 16530, upload-time = "2025-01-02T01:55:30.181Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #37
Fixes #39

`create_sockets()` bound QUIC sockets and `response_headers()` advertised them over alt-svc, but nothing ever constructed a `UDPServer` — so the sockets were neither served nor closed, and `QuicProtocol` / `H3Protocol` were unreachable. This adopts each socket, runs a server on it alongside the TCP listeners, and closes it on the way out.

Closing is the catch: `UDPServer` sends before it closes, which is the shape that hangs on Windows (agronholm/anyio#1237). The sender statsd already needed for that reason becomes `datagram.py`, serving both: an asyncio implementation reaching the `abort()` anyio does not expose, and an anyio one everywhere else. It keeps statsd's unconnected socket from #43, so a peer that is down still cannot surface as `BrokenResourceError` in whichever caller happens to be sending.

Everything below came out of writing the tests, and is why the PR is larger than the feature.

### ASGI state was shared between requests

ASGI has the server pass "a shallow copy of the namespace ... into each subsequent request/response call", and the scope documents its state as the copy "corresponding to this request". Anycorn passed the connection's namespace straight through, so requests sharing a connection shared what they put in it — what one stored, the next read. Hypercorn copies at the same point (`"state": event.state.copy()`), as does uvicorn; the `.copy()` did not survive the port.

It matters most where a connection carries many requests. On HTTP/1.1 a kept-alive connection leaks from one request to the next; on HTTP/2 and HTTP/3 every multiplexed request shares one namespace, so a request can read what a request it never met is storing right now. **This affects HTTP/1.1 and HTTP/2 on `main` today** — it is not specific to the QUIC work, and is here because the HTTP/3 tests are what exposed it.

QUIC additionally copied once per `UDPServer` rather than per connection, so the namespace was shared between unrelated *clients*. Fixed at `ProtocolNegotiated`, where a connection is established — now defence in depth behind the per-request copy, and symmetric with what `TCPServer` does.

### Cleanup only ran on the happy path

`run()` closed its sockets and terminated its workers at the end of the multi-worker branch, so a worker that failed to spawn — or a reloader that raised — left the parent holding open listeners with its children still running. The single-worker branch never closed a socket at all. Both are now owned by an `ExitStack` taken where they come into existence, unwinding children-then-sockets however `run()` exits.

### Concurrent sends collided

QUIC sends from its timer and stream tasks as well as its read loop, and anyio permits one writer per socket — the loser raises `BusyResourceError`. `UDPServer` now holds a send lock of its own, as `TCPServer` does for the same reason. This showed as an intermittent `test_h3_request`: locally the tasks rarely overlapped, on CI they did.

### Testing

End-to-end HTTP/3 through **httpx2 over an anyio transport**, so it runs on trio as well as asyncio — the backend where the datagram path differs and where the `BusyResourceError` lived. aioquic ships an httpx transport in [its examples](https://github.com/aiortc/aioquic/blob/main/examples/httpx_client.py), but it subclasses `QuicConnectionProtocol` and is asyncio only; the request handling here follows it, while the transport underneath drives the sans-io `QuicConnection` the way `QuicProtocol` already does server-side. Its socket comes from `wrap_datagram_socket()`, so the client gets the same win32 treatment as the server.

Certificates come from **trustme**, generated per run, so nothing expires and the client verifies the chain instead of setting `CERT_NONE` — confirmed by pointing it at an unrelated CA, which is rejected. Ports come from anyio's `free_tcp_port`/`free_udp_port` rather than a fixed 4433.

Multiplexing is covered for both HTTP/2 and HTTP/3: requests are issued together against an app that answers none until all have arrived, which only completes if the server carries them at once. The single connection is the harness's doing in both cases, so it is stated as the condition rather than dressed up as a finding.

The HTTP/3 one doubles as the per-request state check for that protocol. Its three requests are in flight together, each writing into the namespace it was handed before any of them answers, so the writes overlap and sharing could not go unnoticed - which the sequential h11 and h2 cases cannot say.

Alongside: roundtrip and close tests for the datagram sockets, twenty concurrent sends through `protocol_send` (nineteen raise without the lock), state isolation for h11, h2 and h3, the worker closing the QUIC sockets it was given, `run()` leaving nothing open or running when it raises, and anycorn still serving with aioquic uninstalled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gXWWFkgiM75VnzkbU5LvR

