### PR TITLE
Deflake the timing-dependent tests

### DIFF
--- a/src/anycorn/tcp_server.py
+++ b/src/anycorn/tcp_server.py
@@ -139,7 +139,7 @@ class TCPServer:
             await self.stream.aclose()
 
     async def _idle_timeout(self) -> None:
-        with anyio.move_on_after(self.config.keep_alive_timeout):
+        with self.context.move_on_after(self.config.keep_alive_timeout):
             await self.context.terminated.wait()
 
         with anyio.CancelScope(shield=True):

--- a/src/anycorn/worker_context.py
+++ b/src/anycorn/worker_context.py
@@ -102,3 +102,13 @@ class WorkerContext:
     def time() -> float:
         """Return the current event-loop time."""
         return anyio.current_time()
+
+    @staticmethod
+    def move_on_after(delay: float | None) -> anyio.CancelScope:
+        """Return a scope that cancels itself once *delay* seconds have passed.
+
+        Goes through the context alongside `sleep()` and `time()` so that the clock a
+        connection ages by is the worker's rather than the wall's, which is what lets
+        tests fire a timeout at a chosen moment instead of waiting one out.
+        """
+        return anyio.move_on_after(delay)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -159,6 +159,7 @@ async def serve_in_memory(
     config: Config | None = None,
     *,
     alpn_protocol: str | None = None,
+    context: WorkerContext | None = None,
 ) -> AsyncIterator[MemoryClientStream]:
     """Run a `TCPServer` against an in-memory socket, yielding the client end.
 
@@ -173,7 +174,7 @@ async def serve_in_memory(
     server = TCPServer(
         ASGIWrapper(app),
         config if config is not None else Config(),
-        WorkerContext(None),
+        context if context is not None else WorkerContext(None),
         {},
         server_stream,
     )

--- a/tests/protocol/test_ws_stream.py
+++ b/tests/protocol/test_ws_stream.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from unittest.mock import Mock, call
 
 import anyio
+import anyio.lowlevel
 import pytest
 from wsproto.events import BytesMessage, TextMessage
 
@@ -489,9 +490,37 @@ async def test_send_connection(stream: WSStream) -> None:
     ]
 
 
+class _PingClock:
+    """Stands in for the ping loop's sleep, so the test decides how often it wakes.
+
+    Lets a fixed number of intervals elapse instantly and then parks, which pins the
+    number of pings to exactly what the test asked for. Sleeping for real instead
+    would tie the count to how fast the machine happens to be.
+    """
+
+    def __init__(self, intervals: int) -> None:
+        self.waits: list[float] = []
+        self._remaining = intervals
+        self._released = anyio.Event()
+
+    async def sleep(self, wait: float) -> None:
+        self.waits.append(wait)
+        if self._remaining > 0:
+            self._remaining -= 1
+            await anyio.lowlevel.checkpoint()
+            return
+        await self._released.wait()
+
+    def release(self) -> None:
+        """Let the parked sleep return, so the loop can notice the stream closed."""
+        self._released.set()
+
+
 @pytest.mark.anyio
 async def test_pings(stream: WSStream) -> None:
     stream.config.websocket_ping_interval = 0.1
+    clock = _PingClock(intervals=1)
+    stream.context.sleep = clock.sleep  # type: ignore[method-assign]
     await stream.handle(
         Request(
             stream_id=1,
@@ -506,13 +535,16 @@ async def test_pings(stream: WSStream) -> None:
         stream.task_group = task_group
         await stream.app_send(cast("WebsocketAcceptEvent", {"type": "websocket.accept"}))
         stream.app_put = AsyncMock()
-        await anyio.sleep(0.15)
+        # One interval elapses, so the loop pings, waits, pings, and then parks
+        await anyio.wait_all_tasks_blocked()
         assert stream.send.call_args_list == [  # type: ignore[attr-defined]
             call(Response(stream_id=1, headers=[], status_code=200)),
             call(Data(stream_id=1, data=b"\x89\x00")),
             call(Data(stream_id=1, data=b"\x89\x00")),
         ]
+        assert clock.waits == [0.1, 0.1]
         await stream.handle(StreamClosed(stream_id=1))
+        clock.release()
 
 
 @pytest.mark.anyio

--- a/tests/test_keep_alive.py
+++ b/tests/test_keep_alive.py
@@ -9,6 +9,7 @@ import h11
 import pytest
 
 from anycorn.config import Config
+from anycorn.worker_context import WorkerContext
 
 from .helpers import serve_in_memory
 
@@ -20,41 +21,70 @@ if TYPE_CHECKING:
     from .helpers import MemoryClientStream
 
 
-KEEP_ALIVE_TIMEOUT = 0.01
 OK = 200
 PIPELINED_REQUESTS = 2
 REQUEST = h11.Request(method="GET", target="/", headers=[(b"host", b"anycorn")])
 
 
-async def slow_framework(
-    _scope: Scope,
-    receive: Callable[[], Awaitable[ASGIReceiveEvent]],
-    send: Callable[[ASGISendEvent], Awaitable[None]],
-) -> None:
-    while True:
-        event = await receive()
-        if event["type"] == "http.disconnect":
-            break
-        if event["type"] == "lifespan.startup":
-            await send({"type": "lifespan.startup.complete"})
-        elif event["type"] == "lifespan.shutdown":
-            await send({"type": "lifespan.shutdown.complete"})
-        elif event["type"] == "http.request" and not event.get("more_body", False):
-            await anyio.sleep(2 * KEEP_ALIVE_TIMEOUT)
-            await send(
-                {
-                    "type": "http.response.start",
-                    "status": 200,
-                    "headers": [(b"content-length", b"0")],
-                }
-            )
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
-            break
+class ManualIdleTimeout(WorkerContext):
+    """A worker whose keep-alive timeout fires when the test says so, not on a clock.
+
+    `move_on_after()` hands back a scope with no deadline, so a connection stays idle
+    indefinitely until `expire()` cancels it. Waiting out a real timeout instead makes
+    the test a race between the deadline and however long a loaded machine takes to
+    get the request read - which it can lose in either direction.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(None)
+        self._scopes: list[anyio.CancelScope] = []
+
+    def move_on_after(self, delay: float | None) -> anyio.CancelScope:  # noqa: ARG002
+        scope = anyio.CancelScope()
+        self._scopes.append(scope)
+        return scope
+
+    def expire(self) -> None:
+        """Fire every keep-alive timeout currently being waited on."""
+        for scope in self._scopes:
+            scope.cancel()
+
+
+def gated_framework(release: anyio.Event) -> Callable:
+    """Return an app that will not answer until *release* is set."""
+
+    async def _app(
+        _scope: Scope,
+        receive: Callable[[], Awaitable[ASGIReceiveEvent]],
+        send: Callable[[ASGISendEvent], Awaitable[None]],
+    ) -> None:
+        while True:
+            event = await receive()
+            if event["type"] == "http.disconnect":
+                break
+            if event["type"] == "lifespan.startup":
+                await send({"type": "lifespan.startup.complete"})
+            elif event["type"] == "lifespan.shutdown":
+                await send({"type": "lifespan.shutdown.complete"})
+            elif event["type"] == "http.request" and not event.get("more_body", False):
+                await release.wait()
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 200,
+                        "headers": [(b"content-length", b"0")],
+                    }
+                )
+                await send({"type": "http.response.body", "body": b"", "more_body": False})
+                break
+
+    return _app
 
 
 def _config() -> Config:
     config = Config()
-    config.keep_alive_timeout = KEEP_ALIVE_TIMEOUT
+    # Never reached: ManualIdleTimeout ignores the delay and waits to be told
+    config.keep_alive_timeout = 60.0
     return config
 
 
@@ -75,9 +105,18 @@ async def _read_response(client: h11.Connection, client_stream: MemoryClientStre
 @pytest.mark.anyio
 async def test_http1_keep_alive_pre_request() -> None:
     """A connection idle before its request completes is closed."""
-    async with serve_in_memory(slow_framework, _config()) as client_stream:
+    context = ManualIdleTimeout()
+    released = anyio.Event()
+    released.set()
+    async with serve_in_memory(
+        gated_framework(released), _config(), context=context
+    ) as client_stream:
         await client_stream.send_all(b"GET")
-        await anyio.sleep(2 * KEEP_ALIVE_TIMEOUT)
+        await anyio.wait_all_tasks_blocked()
+
+        context.expire()
+        await anyio.wait_all_tasks_blocked()
+
         # Only way to confirm closure is to invoke an error
         with pytest.raises(anyio.BrokenResourceError):
             await client_stream.send_all(b"a")
@@ -86,19 +125,31 @@ async def test_http1_keep_alive_pre_request() -> None:
 @pytest.mark.anyio
 async def test_http1_keep_alive_during() -> None:
     """The idle timeout must not fire whilst the app is still working."""
-    async with serve_in_memory(slow_framework, _config()) as client_stream:
+    context = ManualIdleTimeout()
+    release = anyio.Event()
+    async with serve_in_memory(
+        gated_framework(release), _config(), context=context
+    ) as client_stream:
         client = h11.Connection(h11.CLIENT)
         await client_stream.send_all(client.send(REQUEST))
         await client_stream.send_all(client.send(h11.EndOfMessage()))
-        # The framework sleeps for longer than the keep alive timeout before it
-        # responds, so a response arriving at all is the assertion
+        await anyio.wait_all_tasks_blocked()
+
+        # Fire the timeout whilst the app is mid-request: it has been stopped for the
+        # duration, so the connection must survive it
+        context.expire()
+        await anyio.wait_all_tasks_blocked()
+        release.set()
+
         assert (await _read_response(client, client_stream)).status_code == OK
 
 
 @pytest.mark.anyio
 async def test_http1_keep_alive() -> None:
     """A second request on the same connection is served."""
-    async with serve_in_memory(slow_framework, _config()) as client_stream:
+    release = anyio.Event()
+    release.set()
+    async with serve_in_memory(gated_framework(release), _config()) as client_stream:
         client = h11.Connection(h11.CLIENT)
         await client_stream.send_all(client.send(REQUEST))
         await client_stream.send_all(client.send(h11.EndOfMessage()))
@@ -113,7 +164,9 @@ async def test_http1_keep_alive() -> None:
 @pytest.mark.anyio
 async def test_http1_keep_alive_pipelining() -> None:
     """Two requests sent back to back are both served."""
-    async with serve_in_memory(slow_framework, _config()) as client_stream:
+    release = anyio.Event()
+    release.set()
+    async with serve_in_memory(gated_framework(release), _config()) as client_stream:
         await client_stream.send_all(
             b"GET / HTTP/1.1\r\nHost: anycorn\r\n\r\nGET / HTTP/1.1\r\nHost: anycorn\r\n\r\n"
         )


### PR DESCRIPTION
Three tests raced the wall clock and failed intermittently on CI — `test_pings` on macOS, and both keep-alive tests on Linux and Windows, in opposite directions. None of them were testing timing; they were using elapsed time as a proxy for "the thing under test has happened by now", which a loaded runner can invalidate either way.

Each is now driven from a clock the test controls, so the assertion is about behaviour rather than about how fast the machine is. None of the three sleeps at all any more.

**`test_pings`** set a 0.1s ping interval, slept 0.15s and asserted *exactly* two pings — 50ms of headroom on an equality assertion, so too slow loses a ping and too fast gains one. The ping loop already sleeps through `context.sleep`, so the test supplies that instead: one interval elapses instantly, then it parks. The stand-in also records the durations asked for, so the configured interval is now asserted rather than assumed — the old test would have passed with the wrong interval.

**The keep-alive tests** had no such seam: the idle timeout used `anyio.move_on_after` directly. `_pre_request` expected the connection closed once a 0.02s sleep was up and found it still open on Linux; `_during` found it *already* closed mid-response on Windows. A 0.01s timeout is shorter than a loaded runner can be relied upon to take getting from starting the idle timer to reading the request, and lengthening it would only widen the window rather than close it.

So this routes the timeout through the worker context, alongside the `sleep()` and `time()` already there and already used by the ping loop. A test can then supply a context whose scopes carry no deadline and cancel them itself. That also lets the app be gated on an event rather than a sleep, so `_during` now fires the timeout while the request is genuinely in flight — the case it is named for — instead of hoping a sleep lands in the right window.

The only production change is `WorkerContext.move_on_after()` and `TCPServer._idle_timeout` calling it; behaviour is unchanged.

Verified by mutation rather than by the tests going green:

| Mutation | Fails |
|---|---|
| ping loop pings once | `test_pings` |
| idle timeout never closes | `test_http1_keep_alive_pre_request` |
| idle task not stopped whilst app works | `test_http1_keep_alive_during` |

The last reproduces the exact `RemoteProtocolError: can't handle event type ConnectionClosed when role=SERVER` that CI hit on Windows — now deterministically, on both backends. Also 20 consecutive runs of each, and `test_ws_stream.py` runs in about a third of the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gXWWFkgiM75VnzkbU5LvR