### PR TITLE
Fix ten hypercorn open issues across HTTP/1, HTTP/3, WSGI, sockets and the reloader

### DIFF
--- a/src/anycorn/__main__.py
+++ b/src/anycorn/__main__.py
@@ -340,8 +340,11 @@ def main(  # noqa: C901 PLR0913 PLR0912 PLR0915
     if len(server_names) > 0:
         cfg.server_names = server_names
 
-    return run(cfg)
+    # Exit with run()'s code rather than returning it: click runs this in standalone
+    # mode and discards the return value, so `return run(cfg)` would always exit 0 -
+    # a --reload onto a SyntaxError would report success to a supervisor (#269).
+    sys.exit(run(cfg))
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/src/anycorn/__main__.py
+++ b/src/anycorn/__main__.py
@@ -342,7 +342,8 @@ def main(  # noqa: C901 PLR0913 PLR0912 PLR0915
 
     # Exit with run()'s code rather than returning it: click runs this in standalone
     # mode and discards the return value, so `return run(cfg)` would always exit 0 -
-    # a --reload onto a SyntaxError would report success to a supervisor (#269).
+    # a --reload onto a SyntaxError would report success to a supervisor.
+    # https://github.com/pgjones/hypercorn/issues/269
     sys.exit(run(cfg))
 
 

--- a/src/anycorn/app_wrappers.py
+++ b/src/anycorn/app_wrappers.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from types import TracebackType
 
     from .typing import (
         ASGIFramework,
@@ -119,18 +120,30 @@ class WSGIWrapper:
             await sync_spawn(self.run_app, environ, partial(call_soon, send))
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
-    def run_app(self, environ: dict, send: Callable) -> None:
+    def run_app(self, environ: dict, send: Callable) -> None:  # noqa: C901
         """Run the WSGI app and forward the response via *send*."""
-        headers: list[tuple[bytes, bytes]] = []
-        response_started = False
         status_code: int | None = None
+        headers: list[tuple[bytes, bytes]] = []
+        headers_sent = False
 
         def start_response(
             status: str,
             response_headers: list[tuple[str, str]],
-            _exc_info: Exception | None = None,
+            exc_info: tuple[type[BaseException], BaseException, TracebackType] | None = None,
         ) -> None:
-            nonlocal headers, response_started, status_code
+            nonlocal status_code, headers
+
+            if exc_info is not None:
+                try:
+                    if headers_sent:
+                        # Too late to change the response, so surface the error the
+                        # app is reporting rather than swallow it (PEP 3333).
+                        raise exc_info[1].with_traceback(exc_info[2])
+                finally:
+                    exc_info = None  # break the traceback reference cycle
+            elif status_code is not None:
+                msg = "start_response() called more than once without exc_info"
+                raise AssertionError(msg)
 
             raw, _ = status.split(" ", 1)
             status_code = int(raw)
@@ -138,20 +151,31 @@ class WSGIWrapper:
                 (name.lower().encode("latin-1"), value.encode("latin-1"))
                 for name, value in response_headers
             ]
-            response_started = True
 
         response_body = self.app(environ, start_response)
 
+        def send_start() -> None:
+            nonlocal headers_sent
+            if headers_sent:
+                return
+            if status_code is None:
+                msg = "WSGI app did not call start_response"
+                raise RuntimeError(msg)
+            send({"type": "http.response.start", "status": status_code, "headers": headers})
+            headers_sent = True
+
         try:
-            first_chunk = True
             for output in response_body:
-                if first_chunk:
-                    if not response_started:
-                        msg = "WSGI app did not call start_response"
-                        raise RuntimeError(msg)
-                    send({"type": "http.response.start", "status": status_code, "headers": headers})
-                    first_chunk = False
-                send({"type": "http.response.body", "body": output, "more_body": True})
+                # PEP 3333: headers are not sent until there is body data to send - an
+                # empty bytestring is not data, and holding off past it leaves the app
+                # free to replace the status/headers via start_response(exc_info=...).
+                if output:
+                    send_start()
+                    send({"type": "http.response.body", "body": output, "more_body": True})
+            # The iterable is exhausted: flush the headers even when no body was
+            # produced (a HEAD handler, a 204/304, or any empty iterable), so the
+            # response still starts rather than crashing the stream.
+            send_start()
         finally:
             if isinstance(response_body, _SupportsClose):
                 response_body.close()

--- a/src/anycorn/app_wrappers.py
+++ b/src/anycorn/app_wrappers.py
@@ -197,7 +197,9 @@ def _build_environ(scope: HTTPScope, body: bytes) -> dict:
         "PATH_INFO": path.encode("utf8").decode("latin1"),
         "QUERY_STRING": scope["query_string"].decode("ascii"),
         "SERVER_NAME": server[0],
-        "SERVER_PORT": server[1],
+        # PEP 3333 requires every CGI-style environ value to be a native string;
+        # a WSGI app doing environ["SERVER_PORT"] + something breaks on a raw int.
+        "SERVER_PORT": str(server[1]),
         "SERVER_PROTOCOL": f"HTTP/{scope['http_version']}",
         "wsgi.version": (1, 0),
         "wsgi.url_scheme": scope.get("scheme", "http"),

--- a/src/anycorn/config.py
+++ b/src/anycorn/config.py
@@ -51,10 +51,12 @@ def _set_reuse_socket_option(sock: socket.socket) -> None:
 
     On Windows SO_REUSEADDR does not mean what it does on Unix: it lets an unrelated
     socket rebind an address already in active use and hijack it, so a second server
-    started on a busy port binds silently rather than raising (hypercorn #171). asyncio
-    omits SO_REUSEADDR on Windows for exactly this reason. Use SO_EXCLUSIVEADDRUSE there
-    - the Microsoft-recommended way to reserve the port - and SO_REUSEADDR everywhere
+    started on a busy port binds silently rather than raising. asyncio omits
+    SO_REUSEADDR on Windows for exactly this reason. Use SO_EXCLUSIVEADDRUSE there -
+    the Microsoft-recommended way to reserve the port - and SO_REUSEADDR everywhere
     else, where it only relaxes the TIME_WAIT rebind and does not permit hijacking.
+
+    https://github.com/pgjones/hypercorn/issues/171
     """
     if sys.platform == "win32":
         # SO_EXCLUSIVEADDRUSE exists only on Windows, so resolve it dynamically to keep

--- a/src/anycorn/config.py
+++ b/src/anycorn/config.py
@@ -46,6 +46,25 @@ FilePath = AnyStr | os.PathLike
 SocketKind = int | socket.SocketKind
 
 
+def _set_reuse_socket_option(sock: socket.socket) -> None:
+    """Claim the address so a second server on the same port fails instead of stealing it.
+
+    On Windows SO_REUSEADDR does not mean what it does on Unix: it lets an unrelated
+    socket rebind an address already in active use and hijack it, so a second server
+    started on a busy port binds silently rather than raising (hypercorn #171). asyncio
+    omits SO_REUSEADDR on Windows for exactly this reason. Use SO_EXCLUSIVEADDRUSE there
+    - the Microsoft-recommended way to reserve the port - and SO_REUSEADDR everywhere
+    else, where it only relaxes the TIME_WAIT rebind and does not permit hijacking.
+    """
+    if sys.platform == "win32":
+        # SO_EXCLUSIVEADDRUSE exists only on Windows, so resolve it dynamically to keep
+        # the module importable (and statically checkable) on other platforms.
+        exclusive = getattr(socket, "SO_EXCLUSIVEADDRUSE")  # noqa: B009
+        sock.setsockopt(socket.SOL_SOCKET, exclusive, 1)
+    else:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+
 @dataclass
 class Sockets:
     """Container for server sockets grouped by protocol type."""
@@ -293,7 +312,7 @@ class Config:
                         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
                 binding = (host, port)
 
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            _set_reuse_socket_option(sock)
 
             if bind.startswith("unix:"):
                 if self.umask is not None:

--- a/src/anycorn/lifespan.py
+++ b/src/anycorn/lifespan.py
@@ -106,7 +106,7 @@ class Lifespan:
             with anyio.fail_after(self.config.shutdown_timeout):
                 await self.shutdown.wait()
         except TimeoutError as error:
-            msg = "startup"
+            msg = "shutdown"
             raise LifespanTimeoutError(msg) from error
 
     async def asgi_receive(self) -> ASGIReceiveEvent:

--- a/src/anycorn/middleware/dispatcher.py
+++ b/src/anycorn/middleware/dispatcher.py
@@ -17,11 +17,6 @@ if TYPE_CHECKING:
 MAX_QUEUE_SIZE = 10
 
 
-async def _call_app(app: ASGIFramework, scope: Scope, receive: Callable, send: Callable) -> None:
-    # An ASGI app returns an Awaitable, whilst start_soon requires a coroutine function
-    await app(scope, receive, send)
-
-
 class _DispatcherMiddleware:
     def __init__(self, mounts: dict[str, ASGIFramework]) -> None:
         self.mounts = mounts
@@ -72,14 +67,8 @@ class DispatcherMiddleware(_DispatcherMiddleware):
                 await stack.enter_async_context(receive_stream)
 
             tg = await stack.enter_async_context(anyio.create_task_group())
-            for path, app in self.mounts.items():
-                tg.start_soon(
-                    _call_app,
-                    app,
-                    scope,
-                    self.app_queues[path][1].receive,
-                    partial(self.send, path, send),
-                )
+            for path in self.mounts:
+                tg.start_soon(self._run_mount, path, scope, send)
 
             while True:
                 message = await receive()
@@ -87,6 +76,25 @@ class DispatcherMiddleware(_DispatcherMiddleware):
                     await channels[0].send(message)
                 if message["type"] == "lifespan.shutdown":
                     break
+
+    async def _run_mount(self, path: str, scope: Scope, send: Callable) -> None:
+        forward = partial(self.send, path, send)
+        try:
+            await self.mounts[path](scope, self.app_queues[path][1].receive, forward)
+        except Exception:
+            # The ASGI-sanctioned way to decline lifespan is to raise. If that happens
+            # before the app has acknowledged startup, treat this mount as having no
+            # lifespan of its own rather than failing the whole dispatcher; a raise
+            # once it is past startup is a genuine error, so let that propagate.
+            if self.startup_complete[path]:
+                raise
+        # However it opted out - by raising, or by returning without acknowledging -
+        # make sure this mount does not leave the dispatcher's own startup or shutdown
+        # waiting on a completion that will never come.
+        if not self.startup_complete[path]:
+            await forward({"type": "lifespan.startup.complete"})
+        if not self.shutdown_complete[path]:
+            await forward({"type": "lifespan.shutdown.complete"})
 
     async def send(self, path: str, send: Callable, message: dict) -> None:
         """Forward lifespan messages and track startup/shutdown completion across mounted apps."""

--- a/src/anycorn/protocol/h11.py
+++ b/src/anycorn/protocol/h11.py
@@ -198,7 +198,8 @@ class H11Protocol:
                 if self.connection.our_state in {h11.IDLE, h11.SEND_RESPONSE}:
                     # Log it: the status (e.g. 431 for oversized headers) otherwise
                     # goes out with no record of why the request was rejected, which
-                    # is a client-side problem but an opaque one to debug (#157).
+                    # is a client-side problem but an opaque one to debug.
+                    # https://github.com/pgjones/hypercorn/issues/157
                     await self.config.log.info(
                         "Rejecting request from %s: %s (%d)",
                         self.client,

--- a/src/anycorn/protocol/h11.py
+++ b/src/anycorn/protocol/h11.py
@@ -196,6 +196,15 @@ class H11Protocol:
                 event = self.connection.next_event()
             except h11.RemoteProtocolError as error:
                 if self.connection.our_state in {h11.IDLE, h11.SEND_RESPONSE}:
+                    # Log it: the status (e.g. 431 for oversized headers) otherwise
+                    # goes out with no record of why the request was rejected, which
+                    # is a client-side problem but an opaque one to debug (#157).
+                    await self.config.log.info(
+                        "Rejecting request from %s: %s (%d)",
+                        self.client,
+                        error,
+                        error.error_status_hint,
+                    )
                     await self._send_error_response(error.error_status_hint)
                 await self.send(Closed())
                 break

--- a/src/anycorn/protocol/h3.py
+++ b/src/anycorn/protocol/h3.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from aioquic.h3.connection import H3Connection
 from aioquic.h3.events import DataReceived, HeadersReceived
 from aioquic.h3.exceptions import NoAvailablePushIDError
+from aioquic.quic.events import StopSendingReceived, StreamReset
 
 from anycorn.utils import filter_pseudo_headers
 
@@ -62,12 +63,18 @@ class H3Protocol:
         self.send = send
         self.server = server
         self.streams: dict[int, HTTPStream | WSStream] = {}
+        # Streams the peer has reset (RESET_STREAM) or asked us to stop sending on
+        # (STOP_SENDING). aioquic resets our sender for these, so any further
+        # send on them would assert; we skip those sends instead.
+        self._reset_streams: set[int] = set()
         self.task_group = task_group
         self.state = state
         self.tls = tls
 
     async def handle(self, quic_event: QuicEvent) -> None:
         """Handle an incoming QUIC event."""
+        if isinstance(quic_event, (StreamReset, StopSendingReceived)):
+            await self._reset_stream(quic_event.stream_id)
         for event in self.connection.handle_event(quic_event):
             if isinstance(event, HeadersReceived):
                 if not self.context.terminated.is_set():
@@ -85,29 +92,48 @@ class H3Protocol:
 
     async def stream_send(self, event: StreamEvent) -> None:
         """Send a stream event to the remote client."""
-        if isinstance(event, (InformationalResponse, Response)):
-            self.connection.send_headers(
-                event.stream_id,
-                [
-                    (b":status", b"%d" % event.status_code),
-                    *event.headers,
-                    *self.config.response_headers("h3"),
-                ],
-            )
-            await self.send()
-        elif isinstance(event, (Body, Data)):
-            self.connection.send_data(event.stream_id, event.data, False)  # noqa: FBT003
-            await self.send()
-        elif isinstance(event, (EndBody, EndData)):
-            self.connection.send_data(event.stream_id, b"", True)  # noqa: FBT003
-            await self.send()
-        elif isinstance(event, Trailers):
-            self.connection.send_headers(event.stream_id, event.headers)
-            await self.send()
-        elif isinstance(event, StreamClosed):
+        if isinstance(event, StreamClosed):
             self.streams.pop(event.stream_id, None)
-        elif isinstance(event, Request):
+            self._reset_streams.discard(event.stream_id)
+            return
+        if isinstance(event, Request):
             await self._create_server_push(event.stream_id, event.raw_path, event.headers)
+            return
+        if event.stream_id in self._reset_streams:
+            # The peer reset this stream; sending on it would assert in aioquic
+            # ("cannot call write() after reset()") - the app just hasn't noticed
+            # the disconnect yet (hypercorn #352).
+            return
+        try:
+            if isinstance(event, (InformationalResponse, Response)):
+                self.connection.send_headers(
+                    event.stream_id,
+                    [
+                        (b":status", b"%d" % event.status_code),
+                        *event.headers,
+                        *self.config.response_headers("h3"),
+                    ],
+                )
+            elif isinstance(event, (Body, Data)):
+                self.connection.send_data(event.stream_id, event.data, False)  # noqa: FBT003
+            elif isinstance(event, (EndBody, EndData)):
+                self.connection.send_data(event.stream_id, b"", True)  # noqa: FBT003
+            elif isinstance(event, Trailers):
+                self.connection.send_headers(event.stream_id, event.headers)
+        except AssertionError:
+            # A reset that landed in the window before we recorded it: aioquic had
+            # already reset the sender, so the send asserts. Treat the stream as
+            # gone rather than letting it crash the connection (hypercorn #352).
+            await self._reset_stream(event.stream_id)
+            return
+        await self.send()
+
+    async def _reset_stream(self, stream_id: int) -> None:
+        """Forget a peer-reset stream, telling it to close so the app stops sending."""
+        self._reset_streams.add(stream_id)
+        stream = self.streams.pop(stream_id, None)
+        if stream is not None:
+            await stream.handle(StreamClosed(stream_id=stream_id))
 
     async def _create_stream(self, request: HeadersReceived) -> None:
         for name, value in request.headers:

--- a/src/anycorn/protocol/h3.py
+++ b/src/anycorn/protocol/h3.py
@@ -102,7 +102,8 @@ class H3Protocol:
         if event.stream_id in self._reset_streams:
             # The peer reset this stream; sending on it would assert in aioquic
             # ("cannot call write() after reset()") - the app just hasn't noticed
-            # the disconnect yet (hypercorn #352).
+            # the disconnect yet.
+            # https://github.com/pgjones/hypercorn/issues/352
             return
         try:
             if isinstance(event, (InformationalResponse, Response)):
@@ -123,7 +124,8 @@ class H3Protocol:
         except AssertionError:
             # A reset that landed in the window before we recorded it: aioquic had
             # already reset the sender, so the send asserts. Treat the stream as
-            # gone rather than letting it crash the connection (hypercorn #352).
+            # gone rather than letting it crash the connection.
+            # https://github.com/pgjones/hypercorn/issues/352
             await self._reset_stream(event.stream_id)
             return
         await self.send()

--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -273,7 +273,7 @@ class HTTPStream:
         # EndBody is still in flight (the client closing just as the response
         # finalises) would otherwise see a non-CLOSED state and log the request a
         # second time - the reader task with response=None, then this one with the
-        # full response (hypercorn #357).
+        # full response (https://github.com/pgjones/hypercorn/issues/357).
         self.state = ASGIHTTPState.CLOSED
         await self.send(EndBody(stream_id=self.stream_id))
         await self.config.log.access(self.scope, self.response, time() - self.start_time)

--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -269,12 +269,19 @@ class HTTPStream:
             raise UnexpectedMessageError(self.state, message["type"])
 
     async def _send_closed(self) -> None:
-        await self.send(EndBody(stream_id=self.stream_id))
+        # Mark CLOSED before the first await: a StreamClosed event handled while
+        # EndBody is still in flight (the client closing just as the response
+        # finalises) would otherwise see a non-CLOSED state and log the request a
+        # second time - the reader task with response=None, then this one with the
+        # full response (hypercorn #357).
         self.state = ASGIHTTPState.CLOSED
+        await self.send(EndBody(stream_id=self.stream_id))
         await self.config.log.access(self.scope, self.response, time() - self.start_time)
         await self.send(StreamClosed(stream_id=self.stream_id))
 
     async def _send_error_response(self, status_code: int) -> None:
+        # Mark CLOSED before the first await, for the same reason as _send_closed.
+        self.state = ASGIHTTPState.CLOSED
         await self.send(
             Response(
                 stream_id=self.stream_id,
@@ -283,7 +290,6 @@ class HTTPStream:
             )
         )
         await self.send(EndBody(stream_id=self.stream_id))
-        self.state = ASGIHTTPState.CLOSED
         await self.config.log.access(
             self.scope, ResponseSummary(status=status_code, headers=[]), time() - self.start_time
         )

--- a/src/anycorn/protocol/quic.py
+++ b/src/anycorn/protocol/quic.py
@@ -79,8 +79,13 @@ class QuicProtocol:
         self.quic_config = QuicConfiguration(alpn_protocols=H3_ALPN, is_client=False)
         assert config.certfile is not None
         assert config.keyfile is not None
+        # Pass the key password through, as create_ssl_context does for TLS: without
+        # it an encrypted HTTP/3 private key fails to load with "Password was not given
+        # but private key is encrypted" (hypercorn #84).
         self.quic_config.load_cert_chain(
-            certfile=pathlib.Path(config.certfile), keyfile=pathlib.Path(config.keyfile)
+            certfile=pathlib.Path(config.certfile),
+            keyfile=pathlib.Path(config.keyfile),
+            password=config.keyfile_password,
         )
 
     @property

--- a/src/anycorn/protocol/quic.py
+++ b/src/anycorn/protocol/quic.py
@@ -81,7 +81,7 @@ class QuicProtocol:
         assert config.keyfile is not None
         # Pass the key password through, as create_ssl_context does for TLS: without
         # it an encrypted HTTP/3 private key fails to load with "Password was not given
-        # but private key is encrypted" (hypercorn #84).
+        # but private key is encrypted" (https://github.com/pgjones/hypercorn/issues/84).
         self.quic_config.load_cert_chain(
             certfile=pathlib.Path(config.certfile),
             keyfile=pathlib.Path(config.keyfile),

--- a/src/anycorn/protocol/ws_stream.py
+++ b/src/anycorn/protocol/ws_stream.py
@@ -377,7 +377,8 @@ class WSStream:
                 await self._send_wsproto_event(event.response())
             elif isinstance(event, CloseConnection):
                 # Remember what the peer closed with, so the disconnect the app sees
-                # carries that code rather than 1006 (hypercorn #127).
+                # carries that code rather than 1006.
+                # https://github.com/pgjones/hypercorn/issues/127
                 self.close_code = event.code
                 if self.connection.state == ConnectionState.REMOTE_CLOSING:
                     await self._send_wsproto_event(event.response())

--- a/src/anycorn/protocol/ws_stream.py
+++ b/src/anycorn/protocol/ws_stream.py
@@ -219,6 +219,9 @@ class WSStream:
         self.buffer = WebsocketBuffer(config.websocket_max_message_size)
         self.client = client
         self.closed = False
+        # The code the peer closed with, once it has sent a close frame, so the ASGI
+        # disconnect reports it rather than defaulting to 1006 (abnormal closure).
+        self.close_code: int | None = None
         self.config = config
         self.context = context
         self.task_group = task_group
@@ -240,7 +243,7 @@ class WSStream:
         """Return True when the WebSocket stream is in a terminal state."""
         return self.state in {ASGIWebsocketState.CLOSED, ASGIWebsocketState.HTTPCLOSED}
 
-    async def handle(self, event: Event) -> None:  # noqa: C901
+    async def handle(self, event: Event) -> None:  # noqa: C901, PLR0912
         """Handle an incoming stream event."""
         if self.closed:
             return
@@ -293,7 +296,9 @@ class WSStream:
         elif isinstance(event, StreamClosed):
             self.closed = True
             if self.app_put is not None:
-                if self.state in {ASGIWebsocketState.HTTPCLOSED, ASGIWebsocketState.CLOSED}:
+                if self.close_code is not None:
+                    code = self.close_code
+                elif self.state in {ASGIWebsocketState.HTTPCLOSED, ASGIWebsocketState.CLOSED}:
                     code = CloseReason.NORMAL_CLOSURE.value
                 else:
                     code = CloseReason.ABNORMAL_CLOSURE.value
@@ -371,6 +376,9 @@ class WSStream:
             elif isinstance(event, Ping):
                 await self._send_wsproto_event(event.response())
             elif isinstance(event, CloseConnection):
+                # Remember what the peer closed with, so the disconnect the app sees
+                # carries that code rather than 1006 (hypercorn #127).
+                self.close_code = event.code
                 if self.connection.state == ConnectionState.REMOTE_CLOSING:
                     await self._send_wsproto_event(event.response())
                 await self.send(StreamClosed(stream_id=self.stream_id))

--- a/src/anycorn/run.py
+++ b/src/anycorn/run.py
@@ -134,7 +134,11 @@ def run(config: Config) -> int:  # noqa: C901, PLR0912, PLR0915
                     shutdown_event.set()
                     active = False
 
-            exitcode = _join_exited(processes) if exitcode != 0 else exitcode
+            # Only reap again when nothing has failed yet: a non-zero exitcode has
+            # already been captured from a worker the loop reaped and removed, so
+            # re-joining the now-empty list would return 0 and mask the failure - a
+            # reload onto a SyntaxError then exited 0 instead of erroring (#269).
+            exitcode = _join_exited(processes) if exitcode == 0 else exitcode
         return exitcode
 
 

--- a/src/anycorn/run.py
+++ b/src/anycorn/run.py
@@ -137,7 +137,8 @@ def run(config: Config) -> int:  # noqa: C901, PLR0912, PLR0915
             # Only reap again when nothing has failed yet: a non-zero exitcode has
             # already been captured from a worker the loop reaped and removed, so
             # re-joining the now-empty list would return 0 and mask the failure - a
-            # reload onto a SyntaxError then exited 0 instead of erroring (#269).
+            # reload onto a SyntaxError then exited 0 instead of erroring.
+            # https://github.com/pgjones/hypercorn/issues/269
             exitcode = _join_exited(processes) if exitcode == 0 else exitcode
         return exitcode
 

--- a/src/anycorn/tcp_server.py
+++ b/src/anycorn/tcp_server.py
@@ -141,7 +141,7 @@ class TCPServer:
             # errno - EHOSTUNREACH/ENETUNREACH/ETIMEDOUT - that asyncio never maps to
             # ConnectionError, so it would otherwise escape _close() and, since this
             # runs from run()'s finally and from protocol_send, crash the connection
-            # task or propagate back into the app (hypercorn #361).
+            # task or propagate back into the app (https://github.com/pgjones/hypercorn/issues/361).
             await self.stream.aclose()
 
     async def _idle_timeout(self) -> None:

--- a/src/anycorn/tcp_server.py
+++ b/src/anycorn/tcp_server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 from math import inf
-from ssl import SSLError, SSLZeroReturnError
+from ssl import SSLZeroReturnError
 from typing import TYPE_CHECKING
 
 import anyio
@@ -134,8 +134,14 @@ class TCPServer:
             # They're already gone, nothing to do, or it is a SSL stream
             await self.stream.send_eof()
         with contextlib.suppress(
-            SSLError, anyio.ClosedResourceError, anyio.BrokenResourceError, anyio.BusyResourceError
+            OSError, anyio.ClosedResourceError, anyio.BrokenResourceError, anyio.BusyResourceError
         ):
+            # OSError (which SSLError subclasses) for the same reason send_eof above
+            # suppresses it: an abrupt disconnect can surface a network-unreachable
+            # errno - EHOSTUNREACH/ENETUNREACH/ETIMEDOUT - that asyncio never maps to
+            # ConnectionError, so it would otherwise escape _close() and, since this
+            # runs from run()'s finally and from protocol_send, crash the connection
+            # task or propagate back into the app (hypercorn #361).
             await self.stream.aclose()
 
     async def _idle_timeout(self) -> None:
@@ -147,7 +153,9 @@ class TCPServer:
 
     async def _initiate_server_close(self) -> None:
         await self.protocol.handle(Closed())
-        with contextlib.suppress(SSLError, anyio.BrokenResourceError, anyio.BusyResourceError):
+        # OSError (SSLError included) as in _close: aclose on an unreachable peer can
+        # raise a plain OSError that would otherwise escape the idle-timeout task.
+        with contextlib.suppress(OSError, anyio.BrokenResourceError, anyio.BusyResourceError):
             await self.stream.aclose()
 
 

--- a/tests/e2e/test_port_in_use.py
+++ b/tests/e2e/test_port_in_use.py
@@ -1,10 +1,12 @@
 """Integration test: a second anycorn server on a busy port must fail to start.
 
-hypercorn #171: on Windows the listening socket used SO_REUSEADDR, which lets an
-unrelated socket rebind an address already in use - so a second `anycorn` started
-on a port already being served bound silently and stole it instead of failing. This
-runs two real `python -m anycorn` processes: the first serves a port, the second is
-launched on the same port and must exit non-zero rather than come up alongside it.
+On Windows the listening socket used SO_REUSEADDR, which lets an unrelated socket
+rebind an address already in use - so a second `anycorn` started on a port already
+being served bound silently and stole it instead of failing. This runs two real
+`python -m anycorn` processes: the first serves a port, the second is launched on
+the same port and must exit non-zero rather than come up alongside it.
+
+https://github.com/pgjones/hypercorn/issues/171
 """
 
 from __future__ import annotations
@@ -40,7 +42,10 @@ async def _wait_until_serving(base_url: str) -> None:
 async def test_second_server_on_a_used_port_exits_nonzero(
     anyio_backend_name: str, free_tcp_port: int
 ) -> None:
-    """A second server on a port already served must refuse to start (hypercorn #171)."""
+    """A second server on a port already served must refuse to start.
+
+    https://github.com/pgjones/hypercorn/issues/171
+    """
     args = [APP, "--bind", f"127.0.0.1:{free_tcp_port}", "--workers", "1"]
     base_url = f"http://127.0.0.1:{free_tcp_port}"
 

--- a/tests/e2e/test_port_in_use.py
+++ b/tests/e2e/test_port_in_use.py
@@ -1,0 +1,56 @@
+"""Integration test: a second anycorn server on a busy port must fail to start.
+
+hypercorn #171: on Windows the listening socket used SO_REUSEADDR, which lets an
+unrelated socket rebind an address already in use - so a second `anycorn` started
+on a port already being served bound silently and stole it instead of failing. This
+runs two real `python -m anycorn` processes: the first serves a port, the second is
+launched on the same port and must exit non-zero rather than come up alongside it.
+"""
+
+from __future__ import annotations
+
+import anyio
+import httpx2
+import pytest
+
+from tests.e2e._subprocess import anycorn_subprocess
+
+APP = "tests/assets/pid_app.py:app"
+
+
+async def _is_serving(base_url: str) -> bool:
+    try:
+        async with httpx2.AsyncClient(base_url=base_url) as client:
+            await client.get("/")
+    except httpx2.TransportError:
+        return False
+    else:
+        return True
+
+
+async def _wait_until_serving(base_url: str) -> None:
+    with anyio.fail_after(15):
+        while True:
+            if await _is_serving(base_url):
+                return
+            await anyio.sleep(0.1)
+
+
+@pytest.mark.anyio
+async def test_second_server_on_a_used_port_exits_nonzero(
+    anyio_backend_name: str, free_tcp_port: int
+) -> None:
+    """A second server on a port already served must refuse to start (hypercorn #171)."""
+    args = [APP, "--bind", f"127.0.0.1:{free_tcp_port}", "--workers", "1"]
+    base_url = f"http://127.0.0.1:{free_tcp_port}"
+
+    async with anycorn_subprocess(args, anyio_backend_name=anyio_backend_name):
+        await _wait_until_serving(base_url)
+
+        # The second server binds the same port in its parent process, so a refused
+        # bind surfaces as a non-zero exit rather than a running, port-stealing server.
+        async with anycorn_subprocess(args, anyio_backend_name=anyio_backend_name) as second:
+            with anyio.fail_after(15):
+                returncode = await second.wait()
+
+    assert returncode != 0

--- a/tests/e2e/test_reload.py
+++ b/tests/e2e/test_reload.py
@@ -1,10 +1,12 @@
 """Integration test for the reloader's exit status on a failed reload.
 
-hypercorn #269: `--reload` onto a Python SyntaxError exited 0, so a supervisor or
-CI could not tell the reload had failed. Two things had to line up - run() must
-carry the crashed worker's non-zero code out of its supervise loop instead of
-re-joining an already-emptied process list, and the click entrypoint must exit
-with that code rather than discard it (click runs the command in standalone mode).
+`--reload` onto a Python SyntaxError exited 0, so a supervisor or CI could not tell
+the reload had failed. Two things had to line up - run() must carry the crashed
+worker's non-zero code out of its supervise loop instead of re-joining an
+already-emptied process list, and the click entrypoint must exit with that code
+rather than discard it (click runs the command in standalone mode).
+
+https://github.com/pgjones/hypercorn/issues/269
 """
 
 from __future__ import annotations

--- a/tests/e2e/test_reload.py
+++ b/tests/e2e/test_reload.py
@@ -1,0 +1,98 @@
+"""Integration test for the reloader's exit status on a failed reload.
+
+hypercorn #269: `--reload` onto a Python SyntaxError exited 0, so a supervisor or
+CI could not tell the reload had failed. Two things had to line up - run() must
+carry the crashed worker's non-zero code out of its supervise loop instead of
+re-joining an already-emptied process list, and the click entrypoint must exit
+with that code rather than discard it (click runs the command in standalone mode).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import anyio
+import httpx2
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_GOOD_APP = (
+    "async def app(scope, receive, send):\n"
+    "    await send({'type': 'http.response.start', 'status': 200, 'headers': []})\n"
+    "    await send({'type': 'http.response.body', 'body': b'ok'})\n"
+)
+_BROKEN_APP = "async def app(scope, receive, send)  # <- SyntaxError: missing colon\n    pass\n"
+
+
+async def _is_serving(base_url: str) -> bool:
+    try:
+        async with httpx2.AsyncClient(base_url=base_url) as client:
+            await client.get("/")
+    except httpx2.TransportError:
+        return False
+    else:
+        return True
+
+
+async def _wait_until_serving(base_url: str) -> None:
+    with anyio.fail_after(15):
+        while True:
+            if await _is_serving(base_url):
+                return
+            await anyio.sleep(0.1)
+
+
+@pytest.mark.anyio
+async def test_reload_onto_a_syntax_error_exits_nonzero(
+    anyio_backend_name: str, free_tcp_port: int, tmp_path: Path
+) -> None:
+    """A reload onto an unimportable module must fail the process, not exit 0."""
+    app_file = tmp_path / "reload_app.py"
+    app_file.write_text(_GOOD_APP)
+
+    # cwd is on sys.path for `python -m`, so the app in tmp_path is importable, while
+    # anycorn itself still resolves from the environment.
+    process = await anyio.open_process(
+        [
+            sys.executable,
+            "-m",
+            "anycorn",
+            "--reload",
+            "--bind",
+            f"127.0.0.1:{free_tcp_port}",
+            "--workers",
+            "1",
+            "--worker-class",
+            anyio_backend_name,
+            "reload_app:app",
+        ],
+        cwd=str(tmp_path),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        await _wait_until_serving(f"http://127.0.0.1:{free_tcp_port}")
+
+        # Break the module, pushing its mtime forward so the ~1s poller cannot miss it.
+        app_file.write_text(_BROKEN_APP)
+        stamp = app_file.stat().st_mtime + 10
+        os.utime(app_file, (stamp, stamp))
+
+        with anyio.fail_after(30):
+            returncode = await process.wait()
+
+        assert returncode != 0
+    finally:
+        # terminate()/kill() on an already-reaped process raises under asyncio, so
+        # guard each call on the process still running rather than assuming it is.
+        if process.returncode is None:
+            process.terminate()
+            with anyio.move_on_after(5):
+                await process.wait()
+        if process.returncode is None:
+            process.kill()

--- a/tests/middleware/test_dispatcher.py
+++ b/tests/middleware/test_dispatcher.py
@@ -115,9 +115,12 @@ async def test_dispatcher_lifespan_with_a_mount_that_declines() -> None:
     """A mounted app that doesn't support lifespan must not block or crash the others.
 
     Declining lifespan by raising used to propagate out of the task group and take
-    the whole dispatcher down (hypercorn #55); an app that instead just returned
-    without acking left the dispatcher waiting on a startup.complete that never came
-    (#315). Either way, the dispatcher now completes that mount on its behalf.
+    the whole dispatcher down; an app that instead just returned without acking left
+    the dispatcher waiting on a startup.complete that never came. Either way, the
+    dispatcher now completes that mount on its behalf.
+
+    https://github.com/pgjones/hypercorn/issues/55
+    https://github.com/pgjones/hypercorn/issues/315
     """
     app = DispatcherMiddleware({"/api": ScopeFramework("api"), "/legacy": NoLifespanFramework()})
 

--- a/tests/middleware/test_dispatcher.py
+++ b/tests/middleware/test_dispatcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+import anyio
 import pytest
 
 from anycorn.middleware.dispatcher import DispatcherMiddleware
@@ -79,6 +80,14 @@ class ScopeFramework:
         await send({"type": "lifespan.startup.complete"})
 
 
+class NoLifespanFramework:
+    """A framework that declines lifespan the ASGI-sanctioned way: by raising."""
+
+    async def __call__(self, scope: Scope, _receive: Callable, _send: Callable) -> None:
+        msg = f"{scope['type']} protocol is not supported"
+        raise ValueError(msg)
+
+
 @pytest.mark.anyio
 async def test_dispatcher_lifespan() -> None:
     app = DispatcherMiddleware({"/apix": ScopeFramework("apix"), "/api": ScopeFramework("api")})
@@ -93,4 +102,39 @@ async def test_dispatcher_lifespan() -> None:
         return {"type": "lifespan.shutdown"}
 
     await app({"type": "lifespan", "asgi": {"version": "3.0"}, "state": {}}, receive, send)
-    assert sent_events == [{"type": "lifespan.startup.complete"}]
+    # Each mount acked startup but returned without handling shutdown; the dispatcher
+    # completes shutdown on their behalf so the caller's lifespan is not left waiting.
+    assert sent_events == [
+        {"type": "lifespan.startup.complete"},
+        {"type": "lifespan.shutdown.complete"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_dispatcher_lifespan_with_a_mount_that_declines() -> None:
+    """A mounted app that doesn't support lifespan must not block or crash the others.
+
+    Declining lifespan by raising used to propagate out of the task group and take
+    the whole dispatcher down (hypercorn #55); an app that instead just returned
+    without acking left the dispatcher waiting on a startup.complete that never came
+    (#315). Either way, the dispatcher now completes that mount on its behalf.
+    """
+    app = DispatcherMiddleware({"/api": ScopeFramework("api"), "/legacy": NoLifespanFramework()})
+
+    sent_events = []
+
+    async def send(message: dict) -> None:
+        sent_events.append(message)
+
+    messages = iter([{"type": "lifespan.startup"}, {"type": "lifespan.shutdown"}])
+
+    async def receive() -> dict:
+        return next(messages)
+
+    with anyio.fail_after(2):
+        await app({"type": "lifespan", "asgi": {"version": "3.0"}, "state": {}}, receive, send)
+
+    assert sent_events == [
+        {"type": "lifespan.startup.complete"},
+        {"type": "lifespan.shutdown.complete"},
+    ]

--- a/tests/protocol/test_h11.py
+++ b/tests/protocol/test_h11.py
@@ -460,3 +460,33 @@ async def test_protocol_handle_data_post_close(protocol: H11Protocol) -> None:
     assert protocol.stream is None
     # Key is that this doesn't error
     await protocol.handle(RawData(data=b"abcdefghij"))
+
+
+@pytest.mark.anyio
+async def test_protocol_handle_data_after_websocket_upgrade(protocol: H11Protocol) -> None:
+    """Trailing data on a websocket upgrade must not crash the worker (hypercorn #225).
+
+    The bytes after the handshake arrive as a Data event before the app has accepted
+    the connection - while WSStream still has no wsproto connection object. It must
+    answer 400 rather than raise AttributeError on self.connection and take the whole
+    worker down with it.
+    """
+    request = (
+        b"GET / HTTP/1.1\r\n"
+        b"Host: anycorn\r\n"
+        b"Connection: Upgrade\r\n"
+        b"Upgrade: websocket\r\n"
+        b"Sec-WebSocket-Version: 13\r\n"
+        b"Sec-WebSocket-Key: bKdPyn3u98cTfZJSh4TNeQ==\r\n"
+        b"\r\n"
+        b"x"
+    )
+
+    await protocol.handle(RawData(data=request))  # must not raise
+
+    sent = b"".join(
+        event.data
+        for (event, *_), _ in protocol.send.call_args_list  # type: ignore[attr-defined]
+        if isinstance(event, RawData)
+    )
+    assert b"HTTP/1.1 400 " in sent

--- a/tests/protocol/test_h11.py
+++ b/tests/protocol/test_h11.py
@@ -12,6 +12,7 @@ import pytest
 import anycorn.protocol.h11
 from anycorn.config import Config
 from anycorn.events import Closed, RawData, Updated
+from anycorn.logging import Logger
 from anycorn.protocol.events import Body, Data, EndBody, EndData, Request, Response, StreamClosed
 from anycorn.protocol.h11 import H2CProtocolRequiredError, H2ProtocolAssumedError, H11Protocol
 from anycorn.protocol.http_stream import HTTPStream
@@ -490,3 +491,17 @@ async def test_protocol_handle_data_after_websocket_upgrade(protocol: H11Protoco
         if isinstance(event, RawData)
     )
     assert b"HTTP/1.1 400 " in sent
+
+
+@pytest.mark.anyio
+async def test_protocol_logs_a_rejected_request(protocol: H11Protocol) -> None:
+    """A request h11 rejects (e.g. 431 for oversized headers) is logged (hypercorn #157).
+
+    The status was already surfaced correctly via error_status_hint; what was missing
+    is any record of why the request was turned away, which made the rejection opaque.
+    """
+    protocol.config._log = AsyncMock(spec=Logger)
+
+    await protocol.handle(RawData(data=b"broken nonsense\r\n\r\n"))
+
+    protocol.config._log.info.assert_called()  # type: ignore[attr-defined]

--- a/tests/protocol/test_h11.py
+++ b/tests/protocol/test_h11.py
@@ -504,4 +504,4 @@ async def test_protocol_logs_a_rejected_request(protocol: H11Protocol) -> None:
 
     await protocol.handle(RawData(data=b"broken nonsense\r\n\r\n"))
 
-    protocol.config._log.info.assert_called()  # type: ignore[attr-defined]
+    protocol.config._log.info.assert_called()

--- a/tests/protocol/test_h11.py
+++ b/tests/protocol/test_h11.py
@@ -465,12 +465,14 @@ async def test_protocol_handle_data_post_close(protocol: H11Protocol) -> None:
 
 @pytest.mark.anyio
 async def test_protocol_handle_data_after_websocket_upgrade(protocol: H11Protocol) -> None:
-    """Trailing data on a websocket upgrade must not crash the worker (hypercorn #225).
+    """Trailing data on a websocket upgrade must not crash the worker.
 
     The bytes after the handshake arrive as a Data event before the app has accepted
     the connection - while WSStream still has no wsproto connection object. It must
     answer 400 rather than raise AttributeError on self.connection and take the whole
     worker down with it.
+
+    https://github.com/pgjones/hypercorn/issues/225
     """
     request = (
         b"GET / HTTP/1.1\r\n"
@@ -495,10 +497,12 @@ async def test_protocol_handle_data_after_websocket_upgrade(protocol: H11Protoco
 
 @pytest.mark.anyio
 async def test_protocol_logs_a_rejected_request(protocol: H11Protocol) -> None:
-    """A request h11 rejects (e.g. 431 for oversized headers) is logged (hypercorn #157).
+    """A request h11 rejects (e.g. 431 for oversized headers) is logged.
 
     The status was already surfaced correctly via error_status_hint; what was missing
     is any record of why the request was turned away, which made the rejection opaque.
+
+    https://github.com/pgjones/hypercorn/issues/157
     """
     protocol.config._log = AsyncMock(spec=Logger)
 

--- a/tests/protocol/test_h3.py
+++ b/tests/protocol/test_h3.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-import pytest
+from unittest.mock import AsyncMock, MagicMock
 
-from anycorn.protocol.events import StreamClosed
+import pytest
+from aioquic.quic.events import StopSendingReceived, StreamReset
+
+from anycorn.protocol.events import Body, EndBody, StreamClosed
 from anycorn.protocol.h3 import H3Protocol
 
 
@@ -12,6 +15,7 @@ from anycorn.protocol.h3 import H3Protocol
 async def test_stream_send_stream_closed_removes_stream() -> None:
     protocol = H3Protocol.__new__(H3Protocol)
     protocol.streams = {1: object(), 2: object()}
+    protocol._reset_streams = set()
 
     await protocol.stream_send(StreamClosed(stream_id=1))
 
@@ -22,7 +26,79 @@ async def test_stream_send_stream_closed_removes_stream() -> None:
 async def test_stream_send_stream_closed_is_idempotent() -> None:
     protocol = H3Protocol.__new__(H3Protocol)
     protocol.streams = {}
+    protocol._reset_streams = set()
 
     await protocol.stream_send(StreamClosed(stream_id=1))
 
     assert protocol.streams == {}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "quic_event",
+    [
+        StopSendingReceived(error_code=0, stream_id=1),
+        StreamReset(error_code=0, stream_id=1),
+    ],
+)
+async def test_peer_reset_closes_the_stream(quic_event: object) -> None:
+    """A peer STOP_SENDING/RESET_STREAM must tear the stream down, so the app stops.
+
+    aioquic resets our sender on these, so nothing more can be sent; the stream is
+    dropped and handed a StreamClosed so the app sees http.disconnect (hypercorn #352).
+    """
+    protocol = H3Protocol.__new__(H3Protocol)
+    stream = MagicMock()
+    stream.handle = AsyncMock()
+    protocol.streams = {1: stream}
+    protocol._reset_streams = set()
+    protocol.connection = MagicMock()
+    protocol.connection.handle_event = MagicMock(return_value=[])
+
+    await protocol.handle(quic_event)
+
+    assert 1 not in protocol.streams
+    assert 1 in protocol._reset_streams
+    stream.handle.assert_awaited_once_with(StreamClosed(stream_id=1))
+
+
+@pytest.mark.anyio
+async def test_stream_send_skips_a_reset_stream() -> None:
+    """Once a stream is reset, sending on it is skipped, not pushed into aioquic.
+
+    Sending would hit aioquic's "cannot call write() after reset()" assertion.
+    """
+    protocol = H3Protocol.__new__(H3Protocol)
+    protocol.streams = {}
+    protocol._reset_streams = {1}
+    protocol.connection = MagicMock()
+    protocol.send = AsyncMock()
+
+    await protocol.stream_send(Body(stream_id=1, data=b"late"))
+    await protocol.stream_send(EndBody(stream_id=1))
+
+    protocol.connection.send_data.assert_not_called()
+    protocol.send.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_stream_send_survives_a_racing_reset_assertion() -> None:
+    """A reset landing mid-send makes aioquic assert; that must not crash the send.
+
+    If the reset is recorded only after the app's send has begun, the aioquic call
+    asserts. stream_send swallows it and forgets the stream instead (hypercorn #352).
+    """
+    protocol = H3Protocol.__new__(H3Protocol)
+    stream = MagicMock()
+    stream.handle = AsyncMock()
+    protocol.streams = {1: stream}
+    protocol._reset_streams = set()
+    protocol.connection = MagicMock()
+    protocol.connection.send_data.side_effect = AssertionError("cannot call write() after reset()")
+    protocol.send = AsyncMock()
+
+    await protocol.stream_send(EndBody(stream_id=1))  # must not raise
+
+    assert 1 in protocol._reset_streams
+    assert 1 not in protocol.streams
+    protocol.send.assert_not_awaited()

--- a/tests/protocol/test_h3.py
+++ b/tests/protocol/test_h3.py
@@ -5,17 +5,40 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from aioquic.quic.events import StopSendingReceived, StreamReset
+from aioquic.quic.events import QuicEvent, StopSendingReceived, StreamReset
 
+from anycorn.config import Config
 from anycorn.protocol.events import Body, EndBody, StreamClosed
 from anycorn.protocol.h3 import H3Protocol
+from anycorn.typing import ConnectionState, TLSExtension
+from anycorn.worker_context import WorkerContext
+
+
+def _make_protocol() -> H3Protocol:
+    """Build a fully initialised H3Protocol over mock collaborators.
+
+    Goes through __init__ (so streams, _reset_streams and the rest are real) rather
+    than __new__; the quic connection is a mock, and tests that drive the H3
+    connection stub protocol.connection on top of it.
+    """
+    return H3Protocol(
+        MagicMock(),  # app
+        Config(),
+        WorkerContext(None),
+        MagicMock(),  # task_group
+        ConnectionState({}),
+        TLSExtension(),
+        None,  # client
+        None,  # server
+        MagicMock(),  # quic
+        AsyncMock(),  # send
+    )
 
 
 @pytest.mark.anyio
 async def test_stream_send_stream_closed_removes_stream() -> None:
-    protocol = H3Protocol.__new__(H3Protocol)
-    protocol.streams = {1: object(), 2: object()}
-    protocol._reset_streams = set()
+    protocol = _make_protocol()
+    protocol.streams = {1: object(), 2: object()}  # type: ignore[dict-item]
 
     await protocol.stream_send(StreamClosed(stream_id=1))
 
@@ -24,9 +47,7 @@ async def test_stream_send_stream_closed_removes_stream() -> None:
 
 @pytest.mark.anyio
 async def test_stream_send_stream_closed_is_idempotent() -> None:
-    protocol = H3Protocol.__new__(H3Protocol)
-    protocol.streams = {}
-    protocol._reset_streams = set()
+    protocol = _make_protocol()
 
     await protocol.stream_send(StreamClosed(stream_id=1))
 
@@ -41,17 +62,16 @@ async def test_stream_send_stream_closed_is_idempotent() -> None:
         StreamReset(error_code=0, stream_id=1),
     ],
 )
-async def test_peer_reset_closes_the_stream(quic_event: object) -> None:
+async def test_peer_reset_closes_the_stream(quic_event: QuicEvent) -> None:
     """A peer STOP_SENDING/RESET_STREAM must tear the stream down, so the app stops.
 
     aioquic resets our sender on these, so nothing more can be sent; the stream is
     dropped and handed a StreamClosed so the app sees http.disconnect (hypercorn #352).
     """
-    protocol = H3Protocol.__new__(H3Protocol)
+    protocol = _make_protocol()
     stream = MagicMock()
     stream.handle = AsyncMock()
     protocol.streams = {1: stream}
-    protocol._reset_streams = set()
     protocol.connection = MagicMock()
     protocol.connection.handle_event = MagicMock(return_value=[])
 
@@ -68,17 +88,15 @@ async def test_stream_send_skips_a_reset_stream() -> None:
 
     Sending would hit aioquic's "cannot call write() after reset()" assertion.
     """
-    protocol = H3Protocol.__new__(H3Protocol)
-    protocol.streams = {}
+    protocol = _make_protocol()
     protocol._reset_streams = {1}
     protocol.connection = MagicMock()
-    protocol.send = AsyncMock()
 
     await protocol.stream_send(Body(stream_id=1, data=b"late"))
     await protocol.stream_send(EndBody(stream_id=1))
 
     protocol.connection.send_data.assert_not_called()
-    protocol.send.assert_not_awaited()
+    protocol.send.assert_not_awaited()  # type: ignore[attr-defined]
 
 
 @pytest.mark.anyio
@@ -88,17 +106,15 @@ async def test_stream_send_survives_a_racing_reset_assertion() -> None:
     If the reset is recorded only after the app's send has begun, the aioquic call
     asserts. stream_send swallows it and forgets the stream instead (hypercorn #352).
     """
-    protocol = H3Protocol.__new__(H3Protocol)
+    protocol = _make_protocol()
     stream = MagicMock()
     stream.handle = AsyncMock()
     protocol.streams = {1: stream}
-    protocol._reset_streams = set()
     protocol.connection = MagicMock()
     protocol.connection.send_data.side_effect = AssertionError("cannot call write() after reset()")
-    protocol.send = AsyncMock()
 
     await protocol.stream_send(EndBody(stream_id=1))  # must not raise
 
     assert 1 in protocol._reset_streams
     assert 1 not in protocol.streams
-    protocol.send.assert_not_awaited()
+    protocol.send.assert_not_awaited()  # type: ignore[attr-defined]

--- a/tests/protocol/test_h3.py
+++ b/tests/protocol/test_h3.py
@@ -66,7 +66,9 @@ async def test_peer_reset_closes_the_stream(quic_event: QuicEvent) -> None:
     """A peer STOP_SENDING/RESET_STREAM must tear the stream down, so the app stops.
 
     aioquic resets our sender on these, so nothing more can be sent; the stream is
-    dropped and handed a StreamClosed so the app sees http.disconnect (hypercorn #352).
+    dropped and handed a StreamClosed so the app sees http.disconnect.
+
+    https://github.com/pgjones/hypercorn/issues/352
     """
     protocol = _make_protocol()
     stream = MagicMock()
@@ -104,7 +106,9 @@ async def test_stream_send_survives_a_racing_reset_assertion() -> None:
     """A reset landing mid-send makes aioquic assert; that must not crash the send.
 
     If the reset is recorded only after the app's send has begun, the aioquic call
-    asserts. stream_send swallows it and forgets the stream instead (hypercorn #352).
+    asserts. stream_send swallows it and forgets the stream instead.
+
+    https://github.com/pgjones/hypercorn/issues/352
     """
     protocol = _make_protocol()
     stream = MagicMock()

--- a/tests/protocol/test_h3.py
+++ b/tests/protocol/test_h3.py
@@ -17,9 +17,9 @@ from anycorn.worker_context import WorkerContext
 def _make_protocol() -> H3Protocol:
     """Build a fully initialised H3Protocol over mock collaborators.
 
-    Goes through __init__ (so streams, _reset_streams and the rest are real) rather
-    than __new__; the quic connection is a mock, and tests that drive the H3
-    connection stub protocol.connection on top of it.
+    Goes through the real constructor, so streams, _reset_streams and the rest are
+    set up as in production; the quic connection is a mock, and tests that drive the
+    H3 connection stub protocol.connection on top of it.
     """
     return H3Protocol(
         MagicMock(),  # app

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -12,6 +12,7 @@ from anycorn.logging import Logger
 from anycorn.protocol.events import (
     Body,
     EndBody,
+    Event,
     InformationalResponse,
     Request,
     Response,
@@ -221,6 +222,50 @@ async def test_send_response(stream: HTTPStream) -> None:
         call(StreamClosed(stream_id=1)),
     ]
     stream.config._log.access.assert_called()  # type: ignore[unresolved-attribute]
+
+
+@pytest.mark.anyio
+async def test_send_closed_does_not_double_log_on_concurrent_stream_close(
+    stream: HTTPStream,
+) -> None:
+    """A StreamClosed racing the response's completion must not log the request twice.
+
+    hypercorn #357: when the client closes just as the response finalises, the reader
+    task can handle StreamClosed while EndBody is still in flight. Unless the stream
+    is already CLOSED by then, that path logs the request (response=None) and
+    _send_closed goes on to log it again with the full response. Marking CLOSED before
+    the EndBody send closes the window; here the race is forced deterministically by
+    handling StreamClosed from inside the EndBody send itself.
+    """
+    await stream.handle(
+        Request(
+            stream_id=1,
+            http_version="1.1",
+            headers=[],
+            raw_path=b"/",
+            method="GET",
+            state=ConnectionState({}),
+        )
+    )
+    await stream.app_send(
+        cast(
+            "HTTPResponseStartEvent",
+            {"type": "http.response.start", "status": 200, "headers": []},
+        )
+    )
+
+    async def _close_during_end_body(event: Event) -> None:
+        # The reader task running mid-send, exactly as the race schedules it.
+        if isinstance(event, EndBody):
+            await stream.handle(StreamClosed(stream_id=1))
+
+    stream.send = AsyncMock(side_effect=_close_during_end_body)
+
+    await stream.app_send(
+        cast("HTTPResponseBodyEvent", {"type": "http.response.body", "body": b"Body"})
+    )
+
+    assert stream.config._log.access.call_count == 1  # type: ignore[attr-defined]
 
 
 @pytest.mark.anyio

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -230,12 +230,14 @@ async def test_send_closed_does_not_double_log_on_concurrent_stream_close(
 ) -> None:
     """A StreamClosed racing the response's completion must not log the request twice.
 
-    hypercorn #357: when the client closes just as the response finalises, the reader
-    task can handle StreamClosed while EndBody is still in flight. Unless the stream
-    is already CLOSED by then, that path logs the request (response=None) and
-    _send_closed goes on to log it again with the full response. Marking CLOSED before
-    the EndBody send closes the window; here the race is forced deterministically by
-    handling StreamClosed from inside the EndBody send itself.
+    When the client closes just as the response finalises, the reader task can handle
+    StreamClosed while EndBody is still in flight. Unless the stream is already CLOSED
+    by then, that path logs the request (response=None) and _send_closed goes on to log
+    it again with the full response. Marking CLOSED before the EndBody send closes the
+    window; here the race is forced deterministically by handling StreamClosed from
+    inside the EndBody send itself.
+
+    https://github.com/pgjones/hypercorn/issues/357
     """
     await stream.handle(
         Request(

--- a/tests/protocol/test_quic.py
+++ b/tests/protocol/test_quic.py
@@ -62,10 +62,12 @@ def _make_protocol(config: Config) -> QuicProtocol:
 
 
 def test_loads_a_password_protected_http3_key(tmp_path: Path) -> None:
-    """An encrypted HTTP/3 private key loads when keyfile_password is set (hypercorn #84).
+    """An encrypted HTTP/3 private key loads when keyfile_password is set.
 
     Without forwarding the password to aioquic's load_cert_chain, construction raises
     "Password was not given but private key is encrypted".
+
+    https://github.com/pgjones/hypercorn/issues/84
     """
     certfile, keyfile = _write_encrypted_cert(tmp_path)
     config = Config()

--- a/tests/protocol/test_quic.py
+++ b/tests/protocol/test_quic.py
@@ -1,0 +1,89 @@
+"""Tests for the QUIC protocol handler's configuration."""
+
+from __future__ import annotations
+
+import datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from anycorn.config import Config
+from anycorn.protocol.quic import QuicProtocol
+from anycorn.typing import ConnectionState
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY_PASSWORD = "s3cret"  # noqa: S105  # test key encryption password, not a secret
+
+
+def _write_encrypted_cert(directory: Path) -> tuple[str, str]:
+    """Write a self-signed cert and a password-encrypted private key, return their paths."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2020, 1, 1))  # noqa: DTZ001
+        .not_valid_after(datetime.datetime(2050, 1, 1))  # noqa: DTZ001
+        .sign(key, hashes.SHA256())
+    )
+    certfile = directory / "cert.pem"
+    keyfile = directory / "key.pem"
+    certfile.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    keyfile.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.BestAvailableEncryption(_KEY_PASSWORD.encode()),
+        )
+    )
+    return str(certfile), str(keyfile)
+
+
+def _make_protocol(config: Config) -> QuicProtocol:
+    return QuicProtocol(
+        MagicMock(),  # app
+        config,
+        MagicMock(),  # context
+        MagicMock(),  # task_group
+        ConnectionState({}),
+        ("127.0.0.1", 4433),  # server
+        AsyncMock(),  # send
+    )
+
+
+def test_loads_a_password_protected_http3_key(tmp_path: Path) -> None:
+    """An encrypted HTTP/3 private key loads when keyfile_password is set (hypercorn #84).
+
+    Without forwarding the password to aioquic's load_cert_chain, construction raises
+    "Password was not given but private key is encrypted".
+    """
+    certfile, keyfile = _write_encrypted_cert(tmp_path)
+    config = Config()
+    config.certfile = certfile
+    config.keyfile = keyfile
+    config.keyfile_password = _KEY_PASSWORD
+
+    protocol = _make_protocol(config)
+
+    assert protocol.quic_config.private_key is not None
+
+
+def test_encrypted_http3_key_without_password_is_an_error(tmp_path: Path) -> None:
+    """The same key without a password still fails, so the loader isn't silently lenient."""
+    certfile, keyfile = _write_encrypted_cert(tmp_path)
+    config = Config()
+    config.certfile = certfile
+    config.keyfile = keyfile
+
+    with pytest.raises(TypeError, match="Password was not given"):
+        _make_protocol(config)

--- a/tests/protocol/test_ws_stream.py
+++ b/tests/protocol/test_ws_stream.py
@@ -310,11 +310,13 @@ async def test_handle_closed(stream: WSStream) -> None:
 
 @pytest.mark.anyio
 async def test_handle_client_close_reports_its_code(stream: WSStream) -> None:
-    """A clean client close must reach the app as its own code, not 1006 (hypercorn #127).
+    """A clean client close must reach the app as its own code, not 1006.
 
     Before, the CloseConnection from the peer was not recorded, so when the stream then
     closed the disconnect defaulted to ABNORMAL_CLOSURE - the app could not tell a
     graceful client close from a dropped connection.
+
+    https://github.com/pgjones/hypercorn/issues/127
     """
     await stream.handle(
         Request(

--- a/tests/protocol/test_ws_stream.py
+++ b/tests/protocol/test_ws_stream.py
@@ -309,6 +309,35 @@ async def test_handle_closed(stream: WSStream) -> None:
 
 
 @pytest.mark.anyio
+async def test_handle_client_close_reports_its_code(stream: WSStream) -> None:
+    """A clean client close must reach the app as its own code, not 1006 (hypercorn #127).
+
+    Before, the CloseConnection from the peer was not recorded, so when the stream then
+    closed the disconnect defaulted to ABNORMAL_CLOSURE - the app could not tell a
+    graceful client close from a dropped connection.
+    """
+    await stream.handle(
+        Request(
+            stream_id=1,
+            http_version="2",
+            headers=[(b"sec-websocket-version", b"13")],
+            raw_path=b"/",
+            method="GET",
+            state=ConnectionState({}),
+        )
+    )
+    await stream.app_send(cast("WebsocketAcceptEvent", {"type": "websocket.accept"}))
+    stream.app_put = AsyncMock()
+
+    # A masked client close frame carrying code 1000 (a zero mask key leaves the
+    # 2-byte payload - 0x03e8 - unchanged).
+    await stream.handle(Data(stream_id=1, data=b"\x88\x82\x00\x00\x00\x00\x03\xe8"))
+    await stream.handle(StreamClosed(stream_id=1))
+
+    assert stream.app_put.call_args_list == [call({"type": "websocket.disconnect", "code": 1000})]
+
+
+@pytest.mark.anyio
 async def test_send_accept(stream: WSStream) -> None:
     await stream.handle(
         Request(

--- a/tests/test_app_wrappers.py
+++ b/tests/test_app_wrappers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import sys
 from typing import TYPE_CHECKING, Any, cast
 
 import anyio
@@ -74,7 +75,8 @@ async def test_wsgi() -> None:
             "status": 200,
             "type": "http.response.start",
         },
-        {"body": b"", "type": "http.response.body", "more_body": True},
+        # No body message for the app's empty b"" chunk; the final empty body below
+        # is the caller (handle_http) closing the response.
         {"body": b"", "type": "http.response.body", "more_body": False},
     ]
 
@@ -127,7 +129,8 @@ async def test_wsgi2() -> None:
             "status": 200,
             "type": "http.response.start",
         },
-        {"body": b"", "type": "http.response.body", "more_body": True},
+        # No body message for the app's empty b"" chunk; the final empty body below
+        # is the caller (handle_http) closing the response.
         {"body": b"", "type": "http.response.body", "more_body": False},
     ]
 
@@ -265,6 +268,99 @@ async def test_wsgi_generator_app_defers_start_response() -> None:
         {"body": b"hello", "type": "http.response.body", "more_body": True},
         {"body": b"", "type": "http.response.body", "more_body": False},
     ]
+
+
+def _http_scope() -> HTTPScope:
+    return {
+        "http_version": "1.1",
+        "asgi": {},
+        "method": "GET",
+        "headers": [],
+        "path": "/",
+        "root_path": "/",
+        "query_string": b"",
+        "raw_path": b"/",
+        "scheme": "http",
+        "type": "http",
+        "client": ("localhost", 80),
+        "server": None,
+        "extensions": {},
+        "state": ConnectionState({}),
+    }
+
+
+def empty_body_app(_environ: dict, start_response: Callable) -> list[bytes]:
+    # A HEAD handler, a 204/304, or any app that returns an empty iterable.
+    start_response("204 No Content", [("Content-Length", "0")])
+    return []
+
+
+@pytest.mark.anyio
+async def test_wsgi_empty_iterable_still_starts_the_response() -> None:
+    """An app that yields no body must still emit http.response.start (hypercorn #331).
+
+    Gating the start on the first chunk means an empty iterable never starts the
+    response; the caller's following body message then crashes the stream with
+    UnexpectedMessageError. Flush the headers once the iterable is exhausted instead.
+    """
+    app = WSGIWrapper(empty_body_app, 2**16)
+    messages = await _run_app(app, _http_scope())
+    assert messages == [
+        {"type": "http.response.start", "status": 204, "headers": [(b"content-length", b"0")]},
+        {"type": "http.response.body", "body": b"", "more_body": False},
+    ]
+
+
+def empty_then_data_app(_environ: dict, start_response: Callable) -> Iterator[bytes]:
+    start_response("200 OK", [("Content-Length", "5")])
+    yield b""  # not data: must not start the response or produce a body message
+    yield b"hello"
+
+
+@pytest.mark.anyio
+async def test_wsgi_empty_chunk_does_not_start_the_response() -> None:
+    """An empty bytestring is not body data, so it must not flush headers (#331)."""
+    app = WSGIWrapper(empty_then_data_app, 2**16)
+    messages = await _run_app(app, _http_scope())
+    assert messages == [
+        {"type": "http.response.start", "status": 200, "headers": [(b"content-length", b"5")]},
+        {"type": "http.response.body", "body": b"hello", "more_body": True},
+        {"type": "http.response.body", "body": b"", "more_body": False},
+    ]
+
+
+def double_start_response_app(_environ: dict, start_response: Callable) -> list[bytes]:
+    start_response("200 OK", [])
+    start_response("500 Internal Server Error", [])  # second call, no exc_info
+    return [b"x"]
+
+
+@pytest.mark.anyio
+async def test_wsgi_double_start_response_without_exc_info_raises() -> None:
+    """PEP 3333: a second start_response without exc_info is an application error (#331)."""
+    app = WSGIWrapper(double_start_response_app, 2**16)
+    with pytest.raises(AssertionError, match="more than once"):
+        await _run_app(app, _http_scope())
+
+
+def replace_after_send_app(_environ: dict, start_response: Callable) -> Iterator[bytes]:
+    start_response("200 OK", [("Content-Length", "5")])
+    yield b"hello"  # headers are flushed here
+    try:
+        raise ValueError("boom")  # noqa: TRY301
+    except ValueError:
+        # Reporting an error once headers are already sent must re-raise it, not
+        # silently replace the response (PEP 3333).
+        start_response("500 Internal Server Error", [], sys.exc_info())
+    yield b"unreached"
+
+
+@pytest.mark.anyio
+async def test_wsgi_start_response_with_exc_info_after_headers_reraises() -> None:
+    """start_response(exc_info=...) after headers are sent re-raises the error (#331)."""
+    app = WSGIWrapper(replace_after_send_app, 2**16)
+    with pytest.raises(ValueError, match="boom"):
+        await _run_app(app, _http_scope())
 
 
 def test_build_environ_encoding() -> None:

--- a/tests/test_app_wrappers.py
+++ b/tests/test_app_wrappers.py
@@ -385,6 +385,29 @@ def test_build_environ_encoding() -> None:
     assert environ["PATH_INFO"] == "/文".encode().decode("latin-1")
 
 
+def test_build_environ_server_port_is_a_string() -> None:
+    """PEP 3333: environ values are native strings, so SERVER_PORT is not a raw int."""
+    scope: HTTPScope = {
+        "http_version": "1.1",
+        "asgi": {},
+        "method": "GET",
+        "headers": [],
+        "path": "/",
+        "root_path": "",
+        "query_string": b"",
+        "raw_path": b"/",
+        "scheme": "http",
+        "type": "http",
+        "client": ("127.0.0.1", 51234),
+        "server": ("127.0.0.1", 8000),
+        "extensions": {},
+        "state": ConnectionState({}),
+    }
+    environ = _build_environ(scope, b"")
+    assert environ["SERVER_PORT"] == "8000"
+    assert isinstance(environ["SERVER_PORT"], str)
+
+
 def test_build_environ_root_path() -> None:
     scope: HTTPScope = {
         "http_version": "1.0",

--- a/tests/test_app_wrappers.py
+++ b/tests/test_app_wrappers.py
@@ -297,11 +297,13 @@ def empty_body_app(_environ: dict, start_response: Callable) -> list[bytes]:
 
 @pytest.mark.anyio
 async def test_wsgi_empty_iterable_still_starts_the_response() -> None:
-    """An app that yields no body must still emit http.response.start (hypercorn #331).
+    """An app that yields no body must still emit http.response.start.
 
     Gating the start on the first chunk means an empty iterable never starts the
     response; the caller's following body message then crashes the stream with
     UnexpectedMessageError. Flush the headers once the iterable is exhausted instead.
+
+    https://github.com/pgjones/hypercorn/issues/331
     """
     app = WSGIWrapper(empty_body_app, 2**16)
     messages = await _run_app(app, _http_scope())
@@ -319,7 +321,10 @@ def empty_then_data_app(_environ: dict, start_response: Callable) -> Iterator[by
 
 @pytest.mark.anyio
 async def test_wsgi_empty_chunk_does_not_start_the_response() -> None:
-    """An empty bytestring is not body data, so it must not flush headers (#331)."""
+    """An empty bytestring is not body data, so it must not flush headers.
+
+    https://github.com/pgjones/hypercorn/issues/331
+    """
     app = WSGIWrapper(empty_then_data_app, 2**16)
     messages = await _run_app(app, _http_scope())
     assert messages == [
@@ -337,7 +342,10 @@ def double_start_response_app(_environ: dict, start_response: Callable) -> list[
 
 @pytest.mark.anyio
 async def test_wsgi_double_start_response_without_exc_info_raises() -> None:
-    """PEP 3333: a second start_response without exc_info is an application error (#331)."""
+    """PEP 3333: a second start_response without exc_info is an application error.
+
+    https://github.com/pgjones/hypercorn/issues/331
+    """
     app = WSGIWrapper(double_start_response_app, 2**16)
     with pytest.raises(AssertionError, match="more than once"):
         await _run_app(app, _http_scope())
@@ -357,7 +365,10 @@ def replace_after_send_app(_environ: dict, start_response: Callable) -> Iterator
 
 @pytest.mark.anyio
 async def test_wsgi_start_response_with_exc_info_after_headers_reraises() -> None:
-    """start_response(exc_info=...) after headers are sent re-raises the error (#331)."""
+    """start_response(exc_info=...) after headers are sent re-raises the error.
+
+    https://github.com/pgjones/hypercorn/issues/331
+    """
     app = WSGIWrapper(replace_after_send_app, 2**16)
     with pytest.raises(ValueError, match="boom"):
         await _run_app(app, _http_scope())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock, NonCallableMock
 import pytest
 
 import anycorn.config
-from anycorn.config import Config
+from anycorn.config import Config, _set_reuse_socket_option
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -148,6 +148,35 @@ def test_create_sockets_multiple(monkeypatch: MonkeyPatch) -> None:
     config.bind = ["127.0.0.1", "unix:/tmp/anycorn.sock"]
     sockets = config.create_sockets()
     assert len(sockets.insecure_sockets) == 2  # noqa: PLR2004
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SO_REUSEADDR is the Unix path.")
+def test_set_reuse_socket_option_posix_sets_reuseaddr() -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        _set_reuse_socket_option(sock)
+        assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR) == 1
+    finally:
+        sock.close()
+
+
+def test_set_reuse_socket_option_windows_uses_exclusive_addr_use(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """On Windows the port is claimed exclusively, never with SO_REUSEADDR (#171).
+
+    SO_EXCLUSIVEADDRUSE only exists on Windows, so it is patched in here to exercise
+    the branch on any platform; the point is that SO_REUSEADDR - which lets a second
+    server hijack the port on Windows - is not the option that gets set.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(socket, "SO_EXCLUSIVEADDRUSE", -5, raising=False)
+    sock = Mock()
+
+    _set_reuse_socket_option(sock)
+
+    exclusive = getattr(socket, "SO_EXCLUSIVEADDRUSE")  # noqa: B009  # win32-only constant
+    sock.setsockopt.assert_called_once_with(socket.SOL_SOCKET, exclusive, 1)
 
 
 def test_daemon_defaults_true() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,15 @@ if TYPE_CHECKING:
 access_log_format = "bob"
 h11_max_incomplete_size = 4
 
+# The reuse option _create_sockets sets is platform-specific: SO_EXCLUSIVEADDRUSE on
+# Windows (so a second server on a busy port fails, hypercorn #171), SO_REUSEADDR
+# elsewhere. getattr keeps the win32-only constant off the import path on other OSes.
+_EXPECTED_REUSE_OPTION = (
+    getattr(socket, "SO_EXCLUSIVEADDRUSE")  # noqa: B009
+    if sys.platform == "win32"
+    else socket.SO_REUSEADDR
+)
+
 
 def _check_standard_config(config: Config) -> None:
     assert config.access_log_format == access_log_format
@@ -101,7 +110,7 @@ def test_create_sockets_ip(
     sockets = config.create_sockets()
     sock = sockets.insecure_sockets[0]
     mock_socket.assert_called_with(expected_family, socket.SOCK_STREAM)
-    sock.setsockopt.assert_called_with(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)  # type: ignore[attr-defined]
+    sock.setsockopt.assert_called_with(socket.SOL_SOCKET, _EXPECTED_REUSE_OPTION, 1)  # type: ignore[attr-defined]
     sock.bind.assert_called_with(expected_binding)  # type: ignore[attr-defined]
     sock.setblocking.assert_called_with(False)  # type: ignore[attr-defined]  # noqa: FBT003
     sock.set_inheritable.assert_called_with(True)  # type: ignore[attr-defined]  # noqa: FBT003
@@ -117,7 +126,7 @@ def test_create_sockets_unix(monkeypatch: MonkeyPatch) -> None:
     sockets = config.create_sockets()
     sock = sockets.insecure_sockets[0]
     mock_socket.assert_called_with(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.setsockopt.assert_called_with(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)  # type: ignore[attr-defined]
+    sock.setsockopt.assert_called_with(socket.SOL_SOCKET, _EXPECTED_REUSE_OPTION, 1)  # type: ignore[attr-defined]
     sock.bind.assert_called_with("/tmp/anycorn.sock")  # type: ignore[attr-defined] # noqa: S108
     sock.setblocking.assert_called_with(False)  # type: ignore[attr-defined]  # noqa: FBT003
     sock.set_inheritable.assert_called_with(True)  # type: ignore[attr-defined]  # noqa: FBT003
@@ -134,7 +143,7 @@ def test_create_sockets_fd(monkeypatch: MonkeyPatch) -> None:
     sock = sockets.insecure_sockets[0]
     mock_sock_class.assert_called_with(fileno=2)
     sock.getsockopt.assert_called_with(socket.SOL_SOCKET, socket.SO_TYPE)  # type: ignore[attr-defined]
-    sock.setsockopt.assert_called_with(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)  # type: ignore[attr-defined]
+    sock.setsockopt.assert_called_with(socket.SOL_SOCKET, _EXPECTED_REUSE_OPTION, 1)  # type: ignore[attr-defined]
     sock.setblocking.assert_called_with(False)  # type: ignore[attr-defined]  # noqa: FBT003
     sock.set_inheritable.assert_called_with(True)  # type: ignore[attr-defined]  # noqa: FBT003
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,8 +22,9 @@ access_log_format = "bob"
 h11_max_incomplete_size = 4
 
 # The reuse option _create_sockets sets is platform-specific: SO_EXCLUSIVEADDRUSE on
-# Windows (so a second server on a busy port fails, hypercorn #171), SO_REUSEADDR
-# elsewhere. getattr keeps the win32-only constant off the import path on other OSes.
+# Windows (so a second server on a busy port fails), SO_REUSEADDR elsewhere. getattr
+# keeps the win32-only constant off the import path on other OSes.
+# https://github.com/pgjones/hypercorn/issues/171
 _EXPECTED_REUSE_OPTION = (
     getattr(socket, "SO_EXCLUSIVEADDRUSE")  # noqa: B009
     if sys.platform == "win32"
@@ -174,11 +175,13 @@ def test_set_reuse_socket_option_posix_sets_reuseaddr() -> None:
 def test_set_reuse_socket_option_windows_uses_exclusive_addr_use(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """On Windows the port is claimed exclusively, never with SO_REUSEADDR (#171).
+    """On Windows the port is claimed exclusively, never with SO_REUSEADDR.
 
     SO_EXCLUSIVEADDRUSE only exists on Windows, so it is patched in here to exercise
     the branch on any platform; the point is that SO_REUSEADDR - which lets a second
     server hijack the port on Windows - is not the option that gets set.
+
+    https://github.com/pgjones/hypercorn/issues/171
     """
     monkeypatch.setattr(sys, "platform", "win32")
     monkeypatch.setattr(socket, "SO_EXCLUSIVEADDRUSE", -5, raising=False)
@@ -191,13 +194,15 @@ def test_set_reuse_socket_option_windows_uses_exclusive_addr_use(
 
 
 def test_second_server_on_the_same_port_is_refused(free_tcp_port: int) -> None:
-    """A second server must not be able to hijack a port already being served (#171).
+    """A second server must not be able to hijack a port already being served.
 
     Binds a real server socket and starts it listening, then a second socket claims the
     same address exactly as _create_sockets does (via _set_reuse_socket_option) and must
     fail to bind. On Unix SO_REUSEADDR already refuses this, so it passes regardless; the
     fix is what makes Windows behave the same way with SO_EXCLUSIVEADDRUSE rather than
     letting the second bind steal the port - so without the fix this fails on Windows.
+
+    https://github.com/pgjones/hypercorn/issues/171
     """
     first = Config()
     first.bind = [f"127.0.0.1:{free_tcp_port}"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,7 +164,9 @@ def test_set_reuse_socket_option_posix_sets_reuseaddr() -> None:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         _set_reuse_socket_option(sock)
-        assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR) == 1
+        # getsockopt only guarantees a nonzero value for an enabled boolean option;
+        # macOS/BSD returns something other than 1, so assert truthiness, not == 1.
+        assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR) != 0
     finally:
         sock.close()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,6 +190,34 @@ def test_set_reuse_socket_option_windows_uses_exclusive_addr_use(
     sock.setsockopt.assert_called_once_with(socket.SOL_SOCKET, exclusive, 1)
 
 
+def test_second_server_on_the_same_port_is_refused(free_tcp_port: int) -> None:
+    """A second server must not be able to hijack a port already being served (#171).
+
+    Binds a real server socket and starts it listening, then a second socket claims the
+    same address exactly as _create_sockets does (via _set_reuse_socket_option) and must
+    fail to bind. On Unix SO_REUSEADDR already refuses this, so it passes regardless; the
+    fix is what makes Windows behave the same way with SO_EXCLUSIVEADDRUSE rather than
+    letting the second bind steal the port - so without the fix this fails on Windows.
+    """
+    first = Config()
+    first.bind = [f"127.0.0.1:{free_tcp_port}"]
+    sockets = first.create_sockets()
+    try:
+        for listening in sockets.insecure_sockets:
+            listening.listen(first.backlog)
+
+        second = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            _set_reuse_socket_option(second)
+            with pytest.raises(OSError):  # noqa: PT011  # EADDRINUSE / WSAEADDRINUSE
+                second.bind(("127.0.0.1", free_tcp_port))
+        finally:
+            second.close()
+    finally:
+        for sock in sockets.insecure_sockets:
+            sock.close()
+
+
 def test_daemon_defaults_true() -> None:
     assert Config().daemon is True
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -34,6 +34,34 @@ async def test_startup_timeout_error() -> None:
         assert str(exc_info.value).startswith("Timeout whilst awaiting startup")
 
 
+async def _slow_shutdown_framework(
+    _scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
+) -> None:
+    """Complete startup promptly, then never acknowledge shutdown."""
+    while True:
+        message = await receive()
+        if message["type"] == "lifespan.startup":
+            await send({"type": "lifespan.startup.complete"})
+        elif message["type"] == "lifespan.shutdown":
+            await anyio.sleep_forever()
+
+
+@pytest.mark.anyio
+async def test_shutdown_timeout_error() -> None:
+    config = Config()
+    config.shutdown_timeout = 0.01
+    lifespan = Lifespan(ASGIWrapper(_slow_shutdown_framework), config, {})
+    async with anyio.create_task_group() as tg:
+        await tg.start(lifespan.handle_lifespan)
+        await lifespan.wait_for_startup()
+        with pytest.raises(LifespanTimeoutError) as exc_info:
+            await lifespan.wait_for_shutdown()
+        # The message must name the shutdown stage, not startup (it used to say
+        # "startup" here from a copied timeout branch).
+        assert str(exc_info.value).startswith("Timeout whilst awaiting shutdown")
+        tg.cancel_scope.cancel()
+
+
 async def _lifespan_failure(
     _scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
 ) -> None:

--- a/tests/test_tcp_server.py
+++ b/tests/test_tcp_server.py
@@ -40,7 +40,7 @@ async def test_close_suppresses_host_unreachable_oserror() -> None:
     EHOSTUNREACH and its kin (ENETUNREACH, ETIMEDOUT) stay plain OSError. _close()
     runs from run()'s finally - outside its own `except OSError` - and from
     protocol_send, so an escaping OSError crashes the connection task or propagates
-    back into the ASGI app (hypercorn #361).
+    back into the ASGI app (https://github.com/pgjones/hypercorn/issues/361).
     """
     stream = _UnreachableStream()
     server = TCPServer(

--- a/tests/test_tcp_server.py
+++ b/tests/test_tcp_server.py
@@ -1,0 +1,56 @@
+"""Tests for TCPServer connection teardown."""
+
+from __future__ import annotations
+
+import errno
+
+import pytest
+
+from anycorn.app_wrappers import ASGIWrapper
+from anycorn.config import Config
+from anycorn.tcp_server import TCPServer
+from anycorn.worker_context import WorkerContext
+
+from .helpers import empty_framework
+
+
+class _UnreachableStream:
+    """A stream whose teardown raises a network-unreachable OSError.
+
+    asyncio leaves that errno unmapped, as an abrupt client disconnect (a deleted
+    pod, a pulled cable) can produce.
+    """
+
+    def __init__(self) -> None:
+        self.aclose_called = False
+
+    async def send_eof(self) -> None:
+        pass
+
+    async def aclose(self) -> None:
+        self.aclose_called = True
+        raise OSError(errno.EHOSTUNREACH, "No route to host")
+
+
+@pytest.mark.anyio
+async def test_close_suppresses_host_unreachable_oserror() -> None:
+    """_close() must swallow a plain OSError from the stream, not let it escape.
+
+    asyncio maps only a handful of errno (ECONNRESET, EPIPE, ...) to ConnectionError;
+    EHOSTUNREACH and its kin (ENETUNREACH, ETIMEDOUT) stay plain OSError. _close()
+    runs from run()'s finally - outside its own `except OSError` - and from
+    protocol_send, so an escaping OSError crashes the connection task or propagates
+    back into the ASGI app (hypercorn #361).
+    """
+    stream = _UnreachableStream()
+    server = TCPServer(
+        ASGIWrapper(empty_framework),
+        Config(),
+        WorkerContext(None),
+        {},
+        stream,  # type: ignore[arg-type]
+    )
+
+    await server._close()  # must not raise
+
+    assert stream.aclose_called


### PR DESCRIPTION
## Summary

Went through **all 122** of hypercorn's [open issues](https://github.com/pgjones/hypercorn/issues), triaged which describe bugs in code anycorn shares, and fixed the ones that clearly applied and could be covered with deterministic tests. Several others turned out to already be handled by anycorn's careful anyio port — some verified here with new tests. Each fix was verified to fail without the change and pass with it restored. A full triage of every open issue is at the bottom.

Rebased onto `main` (v0.19.0), which already contains the earlier gaps work (#48); this PR is now just the 15 commits below.

## Fixed here

- **[#357](https://github.com/pgjones/hypercorn/issues/357)** — Log each request once when the client closes as the response finalises. `HTTPStream` marked `CLOSED` only after awaiting the `EndBody` send, so a `StreamClosed` during that await double-logged; also an intermittent double access record in the dispatcher e2e test on macOS. Mark `CLOSED` before the first await.
- **[#361](https://github.com/pgjones/hypercorn/issues/361)** — Suppress unmapped `OSError` when closing an unreachable connection. `_close()`'s `aclose()` caught only `SSLError` + anyio errors, so `EHOSTUNREACH`/`ENETUNREACH`/`ETIMEDOUT` escaped and crashed the task or hit the app mid-send. Broadened both `aclose()` sites to `OSError`. (Also contains the SSL-error-on-close in [#314](https://github.com/pgjones/hypercorn/issues/314) / [#261](https://github.com/pgjones/hypercorn/issues/261).)
- **[#352](https://github.com/pgjones/hypercorn/issues/352)** (dup [#296](https://github.com/pgjones/hypercorn/issues/296)) — Stop sending on an HTTP/3 stream the peer has reset. On `STOP_SENDING`/`RESET_STREAM` the app kept calling `send_data` and tripped aioquic's "cannot call write() after reset()". Handle the reset events, skip sends to a reset stream, and catch the race-window assertion.
- **[#331](https://github.com/pgjones/hypercorn/issues/331)** — `WSGIWrapper.run_app` PEP 3333 compliance: empty iterables (HEAD/204/304) now start the response, `b""` chunks don't flush headers early, and `start_response` enforces the `exc_info` / double-call rules.
- **[#55](https://github.com/pgjones/hypercorn/issues/55)** (with [#315](https://github.com/pgjones/hypercorn/issues/315), [#240](https://github.com/pgjones/hypercorn/issues/240)) — `DispatcherMiddleware` tolerates mounts that decline lifespan. Declining by raising took the whole dispatcher down; not acking caused a `LifespanTimeoutError`. Each mount runs through `_run_mount`, which completes its startup/shutdown on its behalf (a genuine post-startup error still propagates).
- **[#127](https://github.com/pgjones/hypercorn/issues/127)** — Report the peer's websocket close code to the app instead of defaulting a clean client close to 1006.
- **[#157](https://github.com/pgjones/hypercorn/issues/157)** — Log HTTP/1 requests h11 rejects mid-parse. The status was already correct (431 via `error_status_hint`); the rejection was just silent. Now emits an info log (client, error, status).
- **[#269](https://github.com/pgjones/hypercorn/issues/269)** — Report a non-zero exit status when a `--reload` fails to import. Two bugs combined to swallow the failure: `run()` reaped the crashed worker inside its supervise loop and then re-joined the now-empty process list on the way out (returning 0), and `main()` returned the exit code where click, invoking the command in standalone mode, discards it and exits 0. Only reap again when nothing has failed, and `sys.exit()` the code explicitly. Click still raises its own `SystemExit(2)` for usage errors, so those codes are unaffected. Added an end-to-end regression test that reloads onto a `SyntaxError` and asserts a non-zero exit.
- **[#84](https://github.com/pgjones/hypercorn/issues/84)** — Pass `keyfile_password` when loading an encrypted HTTP/3 certificate. `QuicProtocol` built its aioquic config with `load_cert_chain(certfile, keyfile)` but never forwarded the password, so an encrypted HTTP/3 key failed with "Password was not given but private key is encrypted" — even though the TLS listeners already pass it. Forward it here too (aioquic encodes a str password to bytes itself, matching the TLS path).
- **[#171](https://github.com/pgjones/hypercorn/issues/171)** — Reserve the listen port exclusively on Windows. `_create_sockets` set `SO_REUSEADDR` on every socket, but on Windows that lets an unrelated socket rebind an address already in active use and take it over, so a second server on a busy port bound silently instead of failing. Set `SO_EXCLUSIVEADDRUSE` on Windows (the documented way to claim the port) and keep `SO_REUSEADDR` on Unix, where it cannot hijack a live port — matching what asyncio does. *The Windows behaviour can't be exercised on the Linux CI runner, so the test drives the platform branch with a patched-in constant.*

## Verified already handled (tests added where useful)

- **[#225](https://github.com/pgjones/hypercorn/issues/225)** — websocket-upgrade trailing-data worker crash; already guarded, added a driven h11-upgrade integration test (removing the guard reproduces the exact crash).
- **[#226](https://github.com/pgjones/hypercorn/issues/226)** — h2 END_STREAM: `EndBody` unblocks before draining, so `_send_data` reaches the `complete` branch.
- **[#125](https://github.com/pgjones/hypercorn/issues/125)** — an uncaught app error on a connected websocket closes with 1011, not 1000.
- **[#258](https://github.com/pgjones/hypercorn/issues/258)** — the dispatcher shutdown `CancelledError` is absorbed by anycorn's lifespan cancel-scope (and the #55 fix makes mounts finish cleanly).
- **[#294](https://github.com/pgjones/hypercorn/issues/294)** — anycorn's redirect middleware is pure ASGI with no event-loop access, so the "no running event loop" crash cannot occur.

## Additional correctness fixes (found while auditing, not tied to a numbered issue)

- **WSGI `SERVER_PORT`** — `_build_environ` passed the port as a raw `int`, but PEP 3333 requires every CGI-style environ value to be a native string. A WSGI app treating `SERVER_PORT` as text would `TypeError`. Now stringified, matching `SERVER_NAME` and the rest of the environ.
- **Lifespan shutdown-timeout message** — `wait_for_shutdown` raised `LifespanTimeoutError("startup")` (a copy of the startup branch), so a shutdown that never completed reported "Timeout whilst awaiting **startup** … the **startup**_timeout configuration is incorrect" — the wrong stage and the wrong config option. Now names the shutdown stage.

## Skipped: [#348](https://github.com/pgjones/hypercorn/issues/348) — HTTP/2 whitespace header -> 400
`h2` 4.3.0 treats it as a connection error (GOAWAY, connection `CLOSED`); no per-stream 400 is possible afterward without disabling h2's inbound validation. anycorn already forwards the correct GOAWAY; the fix belongs upstream in `h2`.

## Also in this PR
Reworked the h3 protocol tests to construct `H3Protocol` through its real `__init__` (a `_make_protocol` helper) rather than `__new__`. `__new__` is now gone from the codebase entirely.

## Test plan
- [x] `ruff check` / `ruff format --check` / `ty check` clean across changed files
- [x] Full test suite passes (397 passed, 2 skipped)
- [x] Each fix's test verified to fail without the change and pass with it restored
- [x] Both `asyncio` and `trio` backends exercised

---

### Full triage of hypercorn's open issues

All 122 open issues as of this PR. The fixed and skipped rows are the ones I engaged with directly; **✅ Already in anycorn** marks issues addressed by earlier anycorn work (mostly PR #2); the remaining statuses are a **title-level triage**, not a deep per-issue analysis. 🔍 rows are the plausible follow-up candidates.

| count | status |
|--:|:--|
| 10 | ✅ Fixed in this PR |
| 3 | ✅ Fixed in this PR (duplicate) |
| 11 | ✅ Already in anycorn |
| 1 | ⏭️ Skipped — upstream |
| 3 | ⏭️ Upstream (h11/h2/aioquic) |
| 38 | 🔍 Bug candidate (follow-up) |
| 29 | 🧩 Feature request |
| 24 | ❓ Question / support / docs |
| 3 | ⚙️ hypercorn-internal / N-A |

| Issue | Title | Status | Note |
|--:|:--|:--|:--|
| [#361](https://github.com/pgjones/hypercorn/issues/361) | Plain OSError (EHOSTUNREACH) escapes TCPServer._close() on abrupt c… | ✅ Fixed in this PR | OSError on abrupt disconnect |
| [#359](https://github.com/pgjones/hypercorn/issues/359) | Change access log atom %({...}e)s to read ASGI scope | 🧩 Feature request | access-log atom semantics change |
| [#357](https://github.com/pgjones/hypercorn/issues/357) | Duplicate access logs | ✅ Fixed in this PR | duplicate access logs |
| [#354](https://github.com/pgjones/hypercorn/issues/354) | Crashes in Python 3.14 | 🔍 Bug candidate (follow-up) | Python 3.14 support |
| [#353](https://github.com/pgjones/hypercorn/issues/353) | serve() parameter type annotations gets in the way | 🧩 Feature request | serve() type-annotation ergonomics |
| [#352](https://github.com/pgjones/hypercorn/issues/352) | `AssertionError: cannot call write() after reset()` | ✅ Fixed in this PR | write() after reset() (HTTP/3) |
| [#351](https://github.com/pgjones/hypercorn/issues/351) | Python 3.14 compatibility - TaskGroup, wait_for, and timeout requir… | ⚙️ hypercorn-internal / N-A | hypercorn asyncio wait_for/timeout; anycorn is anyio |
| [#349](https://github.com/pgjones/hypercorn/issues/349) | Send data in a thread | ❓ Question / support / docs |  |
| [#348](https://github.com/pgjones/hypercorn/issues/348) | Header values with leading/trailing whitespaces in HTTP/2 mode caus… | ⏭️ Skipped — upstream | h2 forces a connection GOAWAY; no per-stream 400 |
| [#347](https://github.com/pgjones/hypercorn/issues/347) | Add support for Abstract Unix Sockets | 🧩 Feature request | abstract unix sockets |
| [#346](https://github.com/pgjones/hypercorn/issues/346) | Add ASGI `pathsend` extension support | 🧩 Feature request | ASGI pathsend extension |
| [#345](https://github.com/pgjones/hypercorn/issues/345) | Why force set_inheritable()? | ❓ Question / support / docs |  |
| [#344](https://github.com/pgjones/hypercorn/issues/344) | Un-graceful termination on Windows | 🔍 Bug candidate (follow-up) | Windows shutdown; PR #2 added the asyncio signal fallback |
| [#340](https://github.com/pgjones/hypercorn/issues/340) | Allow stdout to be directed to one of the log files | 🧩 Feature request |  |
| [#339](https://github.com/pgjones/hypercorn/issues/339) | Singular hypercorn before/after hook | 🧩 Feature request | before/after hooks |
| [#338](https://github.com/pgjones/hypercorn/issues/338) | RuntimeWarning: coroutine 'TCPServer._idle_timeout' was never awaited | 🔍 Bug candidate (follow-up) | idle-timeout coroutine warning; anycorn uses SingleTask |
| [#336](https://github.com/pgjones/hypercorn/issues/336) | Running on https://{ip}:{port}/ message contains a URL that will fa… | ❓ Question / support / docs | cosmetic 'Running on' URL |
| [#335](https://github.com/pgjones/hypercorn/issues/335) | HTTP/2 Server terminates all streams once exceeded | 🔍 Bug candidate (follow-up) | h2 max-concurrent-streams handling |
| [#333](https://github.com/pgjones/hypercorn/issues/333) | Daemon processes | ✅ Already in anycorn | Config.daemon / --daemon added in PR #2 |
| [#331](https://github.com/pgjones/hypercorn/issues/331) | WSGIWrapper violates WSGI protocol | ✅ Fixed in this PR | WSGI PEP 3333 response rules |
| [#330](https://github.com/pgjones/hypercorn/issues/330) | Connection:close ignored? | 🔍 Bug candidate (follow-up) | Connection: close handling |
| [#329](https://github.com/pgjones/hypercorn/issues/329) | TCPServer crash | 🔍 Bug candidate (follow-up) | vague crash report |
| [#327](https://github.com/pgjones/hypercorn/issues/327) | Code 1006 during web socket termination on Google Chrome when outgo… | 🔍 Bug candidate (follow-up) | websocket close with queued data |
| [#325](https://github.com/pgjones/hypercorn/issues/325) | Documentation mentions non-existent TLS version | ❓ Question / support / docs | docs |
| [#324](https://github.com/pgjones/hypercorn/issues/324) | get certificate from client peer | 🧩 Feature request | peer client certificate in scope |
| [#322](https://github.com/pgjones/hypercorn/issues/322) | App timeout | ❓ Question / support / docs |  |
| [#315](https://github.com/pgjones/hypercorn/issues/315) | DispatcherMiddleware throws LifespanTimeoutError | ✅ Fixed in this PR (duplicate) | resolved by the #55 fix |
| [#314](https://github.com/pgjones/hypercorn/issues/314) | Incomplete cleanup when closing response before consuming request w… | 🔍 Bug candidate (follow-up) | SSL-error-on-close is contained by the #361 fix; request-drain is a larger follow-up |
| [#313](https://github.com/pgjones/hypercorn/issues/313) | How to drop a connection without sending a response | ❓ Question / support / docs |  |
| [#311](https://github.com/pgjones/hypercorn/issues/311) | Loggers cannot be pickled but custom loggers are only supported thr… | 🔍 Bug candidate (follow-up) | picklable custom loggers |
| [#308](https://github.com/pgjones/hypercorn/issues/308) | graceful_timeout not respected on Python 3.12 | 🔍 Bug candidate (follow-up) | graceful_timeout not respected |
| [#307](https://github.com/pgjones/hypercorn/issues/307) | Enabling the `ws-per-message-deflate` setting like in uvicorn. | ✅ Already in anycorn | websocket_permessage_deflate is configurable |
| [#306](https://github.com/pgjones/hypercorn/issues/306) | Allow passing custom SSLContext | 🧩 Feature request | custom SSLContext |
| [#301](https://github.com/pgjones/hypercorn/issues/301) | Accept header corrupted with commit d1c1a23 | 🔍 Bug candidate (follow-up) | Accept header corruption (hypercorn-specific commit) |
| [#300](https://github.com/pgjones/hypercorn/issues/300) | `sys:1: RuntimeWarning: coroutine 'QuicProtocol._handle_timer' was … | 🔍 Bug candidate (follow-up) | QUIC timer coroutine warning; anycorn uses SingleTask |
| [#298](https://github.com/pgjones/hypercorn/issues/298) | Hypercorn Does Not Load Environment Variables From Session | ❓ Question / support / docs |  |
| [#297](https://github.com/pgjones/hypercorn/issues/297) | Debugging doesn't work with `serve()`. | ❓ Question / support / docs |  |
| [#296](https://github.com/pgjones/hypercorn/issues/296) | `ERROR    Error in ASGI Framework` `AssertionError: cannot call wri… | ✅ Fixed in this PR (duplicate) | same as #352 |
| [#295](https://github.com/pgjones/hypercorn/issues/295) | `QUIC: recvmsg() unexpectedly returned -1 (errno=90; Message too lo… | 🔍 Bug candidate (follow-up) | QUIC datagram size / recvmsg |
| [#294](https://github.com/pgjones/hypercorn/issues/294) | `HTTPToHTTPSRedirectMiddleware` crashes with `RuntimeError: no runn… | ✅ Already in anycorn | anycorn's redirect middleware has no event-loop access |
| [#284](https://github.com/pgjones/hypercorn/issues/284) | Unbounded Content-Length Parsing Issue | 🔍 Bug candidate (follow-up) | Content-Length bounds (mostly h11) |
| [#280](https://github.com/pgjones/hypercorn/issues/280) | Duplicate Content-Type Parsing Error | ⏭️ Upstream (h11/h2/aioquic) | duplicate Content-Type (h11) |
| [#279](https://github.com/pgjones/hypercorn/issues/279) | Incorrect Parsing When Both Content-Length and Transfer-Encoding Ar… | ⏭️ Upstream (h11/h2/aioquic) | CL+TE smuggling (h11) |
| [#278](https://github.com/pgjones/hypercorn/issues/278) | HTTP Request Method Parsing Error | ⏭️ Upstream (h11/h2/aioquic) | method parsing (h11) |
| [#277](https://github.com/pgjones/hypercorn/issues/277) | Misuse of the CONNECT Method | 🔍 Bug candidate (follow-up) | CONNECT without :path is rejected by h2 before anycorn sees it — not reachable |
| [#273](https://github.com/pgjones/hypercorn/issues/273) | Feature Request: Limit HTTP methods | 🧩 Feature request | limit HTTP methods |
| [#269](https://github.com/pgjones/hypercorn/issues/269) | hypercorn autoreload return exit status 0 when reloading encounters… | ✅ Fixed in this PR | reloader exit status on a failed reload |
| [#266](https://github.com/pgjones/hypercorn/issues/266) | ConnectionResetError during page load | 🔍 Bug candidate (follow-up) | ConnectionResetError |
| [#265](https://github.com/pgjones/hypercorn/issues/265) | RuntimeError on page refresh | 🔍 Bug candidate (follow-up) | RuntimeError on refresh |
| [#264](https://github.com/pgjones/hypercorn/issues/264) | ssl error | ❓ Question / support / docs |  |
| [#263](https://github.com/pgjones/hypercorn/issues/263) | Count of pending requests | 🧩 Feature request | pending-request count |
| [#261](https://github.com/pgjones/hypercorn/issues/261) | SSL: APPLICATION_DATA_AFTER_CLOSE_NOTIFY | 🔍 Bug candidate (follow-up) | SSL data-after-close-notify |
| [#260](https://github.com/pgjones/hypercorn/issues/260) | Can we have a default config filename? | 🧩 Feature request | default config filename |
| [#258](https://github.com/pgjones/hypercorn/issues/258) | `DispatcherMiddleware` causes `CancelledError` on shudown | ✅ Already in anycorn | absorbed by the lifespan cancel-scope; with the #55 fix mounts finish cleanly |
| [#254](https://github.com/pgjones/hypercorn/issues/254) | HTTP2 Trailers not being sent | ✅ Already in anycorn | H2 trailers fixed in PR #2 |
| [#250](https://github.com/pgjones/hypercorn/issues/250) | Documentation needs an http2 example | ❓ Question / support / docs | docs |
| [#249](https://github.com/pgjones/hypercorn/issues/249) | feat: configure `hypercorn` with environment variables | 🧩 Feature request | env-var configuration |
| [#247](https://github.com/pgjones/hypercorn/issues/247) | Type hint for check_multiprocess_shutdown_event is confusing for mypy | 🧩 Feature request | typing of check_multiprocess_shutdown_event |
| [#245](https://github.com/pgjones/hypercorn/issues/245) | Hypercorn processes daemon property fails multiprocessing.Process /… | ✅ Already in anycorn | daemon=False now possible (Config.daemon, PR #2) |
| [#244](https://github.com/pgjones/hypercorn/issues/244) | error `hypercorn --config python:hypercorn_config.config` | ❓ Question / support / docs |  |
| [#243](https://github.com/pgjones/hypercorn/issues/243) | Opentelemetry Tracing + Logging Issue | ❓ Question / support / docs | opentelemetry |
| [#242](https://github.com/pgjones/hypercorn/issues/242) | ProxyFixMiddleware: Turns out GCP LBs and possibly AWS LBs only hav… | 🔍 Bug candidate (follow-up) | ProxyFix x-forwarded-proto; anycorn has proxy_fix |
| [#240](https://github.com/pgjones/hypercorn/issues/240) | Cannot start WSGI application using Dispatcher middleware to suppor… | ✅ Fixed in this PR (duplicate) | resolved by the #55 fix |
| [#238](https://github.com/pgjones/hypercorn/issues/238) | Unexpected "shutdown without Lifespan support" error on Hypercorn 0… | 🔍 Bug candidate (follow-up) | lifespan support error; PR #2 touched lifespan |
| [#235](https://github.com/pgjones/hypercorn/issues/235) | TCP server keep-alive times out even though data is being received. | 🔍 Bug candidate (follow-up) | keep-alive timeout despite traffic |
| [#234](https://github.com/pgjones/hypercorn/issues/234) | pytest-cov / pytest-sugar not included in pyproject.toml | ⚙️ hypercorn-internal / N-A | hypercorn dev deps |
| [#231](https://github.com/pgjones/hypercorn/issues/231) | Getting permission Error [WinError 10013] An attempt was made to ac… | ❓ Question / support / docs | Windows/IIS environment |
| [#229](https://github.com/pgjones/hypercorn/issues/229) | Can the ASGI application be specified in the config file? | 🧩 Feature request | app path in config |
| [#226](https://github.com/pgjones/hypercorn/issues/226) | Occassionally with HTTP2, server does not send "End Stream" flag as… | ✅ Already in anycorn | END_STREAM emitted via the EndBody unblock/drain/complete path |
| [#225](https://github.com/pgjones/hypercorn/issues/225) | Entire hypercorn server crashes when receiving trailing data on a w… | ✅ Already in anycorn | already guarded; full-path regression test added here |
| [#221](https://github.com/pgjones/hypercorn/issues/221) | FastAPI deployed with hypercorn in GCP Cloud Run returning 503 spor… | ❓ Question / support / docs |  |
| [#219](https://github.com/pgjones/hypercorn/issues/219) | Performance issue | ❓ Question / support / docs | performance |
| [#215](https://github.com/pgjones/hypercorn/issues/215) | Is Hypercorn pre-fork or post-fork? How can I integrate it with ope… | ❓ Question / support / docs |  |
| [#214](https://github.com/pgjones/hypercorn/issues/214) | Need clear documentation for configuration | ❓ Question / support / docs | docs |
| [#210](https://github.com/pgjones/hypercorn/issues/210) | disconnect detection broken when running with trio | 🔍 Bug candidate (follow-up) | trio disconnect detection; anycorn is anyio |
| [#202](https://github.com/pgjones/hypercorn/issues/202) | SSL shutdown timed out | 🔍 Bug candidate (follow-up) | SSL shutdown timeout |
| [#200](https://github.com/pgjones/hypercorn/issues/200) | use_reloader not working as intended  | 🔍 Bug candidate (follow-up) | use_reloader |
| [#198](https://github.com/pgjones/hypercorn/issues/198) | Websocket endpoint and ProxyFixMiddleware | 🔍 Bug candidate (follow-up) | ws + ProxyFix |
| [#196](https://github.com/pgjones/hypercorn/issues/196) | Handling log file rotation | 🧩 Feature request | log rotation |
| [#195](https://github.com/pgjones/hypercorn/issues/195) | Analog to uvicorn/gunicorn `--forwarded-allow-ips` | 🧩 Feature request | forwarded-allow-ips |
| [#192](https://github.com/pgjones/hypercorn/issues/192) | How could I ignore all the hypercorn output? | ❓ Question / support / docs |  |
| [#191](https://github.com/pgjones/hypercorn/issues/191) | question: running ProcessPoolExecutor inside web-app served by hype… | ❓ Question / support / docs | ProcessPoolExecutor (see #245) |
| [#189](https://github.com/pgjones/hypercorn/issues/189) | Error : unable to perform operation on <TCPTransport>; the handler … | 🔍 Bug candidate (follow-up) | closed-transport error |
| [#184](https://github.com/pgjones/hypercorn/issues/184) | `InvalidStateError` during termination when running hypercorn progr… | 🔍 Bug candidate (follow-up) | InvalidStateError via anyio; relevant to anycorn |
| [#180](https://github.com/pgjones/hypercorn/issues/180) | Graceful shutdown not possible on Windows | 🔍 Bug candidate (follow-up) | Windows graceful shutdown; PR #2 signal work relates |
| [#176](https://github.com/pgjones/hypercorn/issues/176) | Improve WSGI behavior for large requests. | 🔍 Bug candidate (follow-up) | WSGI large requests; PR #2 touched WSGI |
| [#174](https://github.com/pgjones/hypercorn/issues/174) | Support for PROXY-Protocol | 🧩 Feature request | PROXY protocol |
| [#171](https://github.com/pgjones/hypercorn/issues/171) | Running a second server on the same port doesn't fail on Windows | ✅ Fixed in this PR | SO_EXCLUSIVEADDRUSE on Windows (verified via unit test, not Windows CI) |
| [#170](https://github.com/pgjones/hypercorn/issues/170) | Socket remains ESTABLISHED after `keep_alive_timeout` | 🔍 Bug candidate (follow-up) | socket stays ESTABLISHED after keep-alive |
| [#169](https://github.com/pgjones/hypercorn/issues/169) | Implement HTTP CONNECT with Hypercorn | 🧩 Feature request | HTTP CONNECT |
| [#168](https://github.com/pgjones/hypercorn/issues/168) | Raise h11 and h2 exceptions in debug mode | 🧩 Feature request | raise h11/h2 exceptions in debug |
| [#167](https://github.com/pgjones/hypercorn/issues/167) | keep-alive connection re-use is still slowing down HTTP clients | 🔍 Bug candidate (follow-up) | keep-alive reuse latency |
| [#160](https://github.com/pgjones/hypercorn/issues/160) | Binding to both IPv4 and IPv6 for a given host on an available port | 🧩 Feature request | bind IPv4+IPv6 on one port |
| [#157](https://github.com/pgjones/hypercorn/issues/157) | h11 protocol surfaces 431 (request headers too large) as 400 withou… | ✅ Fixed in this PR | log HTTP/1 requests h11 rejects |
| [#141](https://github.com/pgjones/hypercorn/issues/141) | Changelogs are not visible in git tags | ⚙️ hypercorn-internal / N-A | hypercorn repo/tags meta |
| [#137](https://github.com/pgjones/hypercorn/issues/137) | application_path is ignored | 🔍 Bug candidate (follow-up) | application_path ignored |
| [#135](https://github.com/pgjones/hypercorn/issues/135) | dispatcher.py / DispatcherMiddleware review | 🔍 Bug candidate (follow-up) | dispatcher review |
| [#127](https://github.com/pgjones/hypercorn/issues/127) | Hypercorn server websocket consider close code as 1006 upon client … | ✅ Fixed in this PR | peer close code reported to the app |
| [#125](https://github.com/pgjones/hypercorn/issues/125) | Websocket connection with 1000 (CLOSE_NORMAL) upon uncaught excepti… | ✅ Already in anycorn | app error closes a connected ws with 1011 via app_send(None) |
| [#120](https://github.com/pgjones/hypercorn/issues/120) | hypercorn overrides application logging handlers | 🔍 Bug candidate (follow-up) | uses named loggers, not root; app handlers not touched |
| [#119](https://github.com/pgjones/hypercorn/issues/119) | Very high memory usage? | ❓ Question / support / docs | memory usage |
| [#114](https://github.com/pgjones/hypercorn/issues/114) | AssertionError: first packet must be INITIAL when using multiple wo… | 🔍 Bug candidate (follow-up) | QUIC multi-worker INITIAL assertion |
| [#106](https://github.com/pgjones/hypercorn/issues/106) | Hypercorn skip socket shutdown when cancelled with trio | 🔍 Bug candidate (follow-up) | skip socket shutdown when cancelled (trio); anyio-relevant |
| [#99](https://github.com/pgjones/hypercorn/issues/99) | Support reloading non-python files | 🧩 Feature request | reload non-python files |
| [#96](https://github.com/pgjones/hypercorn/issues/96) | Readyness callback in `serve()` function. | 🧩 Feature request | readiness callback in serve() |
| [#93](https://github.com/pgjones/hypercorn/issues/93) | Is it possible to customize the error log? | ❓ Question / support / docs |  |
| [#92](https://github.com/pgjones/hypercorn/issues/92) | Access log prints only part of request path when using FastAPI subapps | ✅ Already in anycorn | subapp access-log path fixed via dispatcher scope copy (PR #2) |
| [#91](https://github.com/pgjones/hypercorn/issues/91) | Error deploying ver 0.14.3 on DigitalOcean Apps Platform | ❓ Question / support / docs | deployment |
| [#89](https://github.com/pgjones/hypercorn/issues/89) | Issue when sending large payload (HTTP CODE 400 or 104) | 🔍 Bug candidate (follow-up) | large payload 400/104 |
| [#85](https://github.com/pgjones/hypercorn/issues/85) | Specifying both IPv4 and IPv6 binds | 🧩 Feature request | IPv4+IPv6 binds (see #160) |
| [#84](https://github.com/pgjones/hypercorn/issues/84) | HTTP/3 [ Password was not given but private key is encrypted ] | ✅ Fixed in this PR | forward keyfile_password to the HTTP/3 cert loader |
| [#81](https://github.com/pgjones/hypercorn/issues/81) | Limit the number of currently open sockets | 🧩 Feature request | limit open sockets |
| [#78](https://github.com/pgjones/hypercorn/issues/78) | Config typing as a Protocol | 🧩 Feature request | Config as Protocol |
| [#74](https://github.com/pgjones/hypercorn/issues/74) | Check ContextVar set in lifespan is available in requests for async… | ❓ Question / support / docs | ContextVar in lifespan |
| [#73](https://github.com/pgjones/hypercorn/issues/73) | Support SNI | 🧩 Feature request | SNI |
| [#72](https://github.com/pgjones/hypercorn/issues/72) | Add a dev cert option | 🧩 Feature request | dev cert option |
| [#71](https://github.com/pgjones/hypercorn/issues/71) | More process options | 🧩 Feature request | more process options |
| [#70](https://github.com/pgjones/hypercorn/issues/70) | Possible to disable lifespan in config? | 🧩 Feature request | disable lifespan in config |
| [#62](https://github.com/pgjones/hypercorn/issues/62) | Implement the TLS extension | ✅ Already in anycorn | TLS extension implemented (build_tls_extension) |
| [#55](https://github.com/pgjones/hypercorn/issues/55) | Fix dispatcher middleware for apps that don't use lifespan | ✅ Fixed in this PR | dispatcher tolerates mounts without lifespan |
| [#50](https://github.com/pgjones/hypercorn/issues/50) | Task was destroyed but it is pending!  | 🔍 Bug candidate (follow-up) | 'Task was destroyed but pending' |
| [#40](https://github.com/pgjones/hypercorn/issues/40) | How to integrate hypercorn's loggers into existing logging setup | ❓ Question / support / docs | logging integration |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZR77xNKLjWiP3Cnwq91ah