### PR TITLE
Turn an unmatched websocket away as a websocket

### DIFF
--- a/src/anycorn/middleware/dispatcher.py
+++ b/src/anycorn/middleware/dispatcher.py
@@ -30,15 +30,38 @@ class _DispatcherMiddleware:
                     local_scope = scope.copy()
                     local_scope["root_path"] = local_scope.get("root_path", "") + path
                     return await app(local_scope, receive, send)
+            if scope["type"] == "websocket":
+                await self._reject_websocket(scope, send)
+            else:
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 404,
+                        "headers": [(b"content-length", b"0")],
+                    }
+                )
+                await send({"type": "http.response.body"})
+        return None
+
+    async def _reject_websocket(self, scope: Scope, send: Callable) -> None:
+        """Say there is nothing mounted here, as fully as the server allows.
+
+        An HTTP response is not something a websocket peer can be sent, so a 404
+        needs the denial response extension. Where the server offers it the client
+        learns why it was turned away; where it does not, closing is all there is.
+        Mirrors HTTPToHTTPSRedirectMiddleware, which chooses the same way.
+        """
+        if "websocket.http.response" in scope.get("extensions", {}):
             await send(
                 {
-                    "type": "http.response.start",
+                    "type": "websocket.http.response.start",
                     "status": 404,
                     "headers": [(b"content-length", b"0")],
                 }
             )
-            await send({"type": "http.response.body"})
-        return None
+            await send({"type": "websocket.http.response.body"})
+        else:
+            await send({"type": "websocket.close"})
 
     async def _handle_lifespan(self, scope: Scope, receive: Callable, send: Callable) -> None:
         pass

--- a/tests/middleware/test_dispatcher.py
+++ b/tests/middleware/test_dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock
 
 import anyio
 import pytest
@@ -141,3 +142,50 @@ async def test_dispatcher_lifespan_with_a_mount_that_declines() -> None:
         {"type": "lifespan.startup.complete"},
         {"type": "lifespan.shutdown.complete"},
     ]
+
+
+@pytest.mark.anyio
+async def test_dispatcher_denies_an_unmatched_websocket_with_404() -> None:
+    """Where the server offers the denial response extension, say why - a 404.
+
+    An http.response.start is not something a websocket peer can be sent, which is
+    what an unmatched websocket used to get.
+    """
+    sent: list[dict] = []
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    app = DispatcherMiddleware({"/mounted": AsyncMock()})
+    scope = {
+        "type": "websocket",
+        "path": "/elsewhere",
+        "headers": [],
+        "root_path": "",
+        # As WSStream always advertises it
+        "extensions": {"websocket.http.response": {}},
+    }
+
+    await app(scope, AsyncMock(), send)  # type: ignore[arg-type]
+
+    assert [message["type"] for message in sent] == [
+        "websocket.http.response.start",
+        "websocket.http.response.body",
+    ]
+    assert sent[0]["status"] == 404  # noqa: PLR2004
+
+
+@pytest.mark.anyio
+async def test_dispatcher_closes_an_unmatched_websocket_without_the_extension() -> None:
+    """Without it, closing is all a websocket peer can be told."""
+    sent: list[dict] = []
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    app = DispatcherMiddleware({"/mounted": AsyncMock()})
+    scope = {"type": "websocket", "path": "/elsewhere", "headers": [], "root_path": ""}
+
+    await app(scope, AsyncMock(), send)  # type: ignore[arg-type]
+
+    assert [message["type"] for message in sent] == ["websocket.close"]


### PR DESCRIPTION
An unmatched websocket scope was answered with http.response.start, which is not something a websocket peer can be sent. Deny it with a 404 through ASGI's denial response extension, which WSStream advertises on every websocket scope it builds, and close where a server does not offer it.

Mirrors HTTPToHTTPSRedirectMiddleware, which already chooses between a denial response and a close the same way.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK