### PR TITLE
Pass on a mounted app's lifespan failure rather than completing for it

### DIFF
--- a/src/anycorn/middleware/dispatcher.py
+++ b/src/anycorn/middleware/dispatcher.py
@@ -83,6 +83,8 @@ class DispatcherMiddleware(_DispatcherMiddleware):
         }
         self.startup_complete = dict.fromkeys(self.mounts, False)
         self.shutdown_complete = dict.fromkeys(self.mounts, False)
+        # Mounts that reported a failure, so nothing is later completed on their behalf
+        self.failed = dict.fromkeys(self.mounts, False)
 
         async with AsyncExitStack() as stack:
             for send_stream, receive_stream in self.app_queues.values():
@@ -109,8 +111,15 @@ class DispatcherMiddleware(_DispatcherMiddleware):
             # before the app has acknowledged startup, treat this mount as having no
             # lifespan of its own rather than failing the whole dispatcher; a raise
             # once it is past startup is a genuine error, so let that propagate.
-            if self.startup_complete[path]:
+            # So is one from a mount that reported a failure: passing that on is what
+            # raises here, and swallowing it leaves the server waiting out its startup
+            # timeout for an acknowledgement that is never coming.
+            if self.startup_complete[path] or self.failed[path]:
                 raise
+        # A mount that said it failed has had that passed on already; completing for
+        # it here would take it back, and report a worker that cannot serve as ready.
+        if self.failed[path]:
+            return
         # However it opted out - by raising, or by returning without acknowledging -
         # make sure this mount does not leave the dispatcher's own startup or shutdown
         # waiting on a completion that will never come.
@@ -129,3 +138,9 @@ class DispatcherMiddleware(_DispatcherMiddleware):
             self.shutdown_complete[path] = True
             if all(self.shutdown_complete.values()):
                 await send({"type": "lifespan.shutdown.complete"})
+        elif message["type"] in {"lifespan.startup.failed", "lifespan.shutdown.failed"}:
+            # One mount that cannot start is the dispatcher failing to start. This
+            # used to be dropped, and the mount then completed on its way out, so a
+            # worker whose app had said it could not run reported itself ready.
+            self.failed[path] = True
+            await send(message)

--- a/tests/middleware/test_dispatcher.py
+++ b/tests/middleware/test_dispatcher.py
@@ -144,6 +144,49 @@ async def test_dispatcher_lifespan_with_a_mount_that_declines() -> None:
     ]
 
 
+class FailingLifespanFramework:
+    """A framework whose startup genuinely fails, the ASGI way: by saying so."""
+
+    async def __call__(self, _scope: Scope, receive: Callable, send: Callable) -> None:
+        message = await receive()
+        if message["type"] == "lifespan.startup":
+            await send({"type": "lifespan.startup.failed", "message": "no database"})
+
+
+@pytest.mark.anyio
+async def test_dispatcher_lifespan_with_a_mount_that_fails_startup() -> None:
+    """A mount that cannot start must fail the dispatcher, not be completed for.
+
+    The failure used to be dropped - nothing forwarded it - and the mount was then
+    completed on its way out, so a worker whose app had said it could not run
+    reported itself started. Declining lifespan (raising, or returning without an
+    ack) is still treated as having none, which the test above covers.
+    """
+    app = DispatcherMiddleware(
+        {"/api": ScopeFramework("api"), "/broken": FailingLifespanFramework()}
+    )
+
+    sent_events = []
+
+    async def send(message: dict) -> None:
+        sent_events.append(message)
+
+    messages = iter([{"type": "lifespan.startup"}, {"type": "lifespan.shutdown"}])
+
+    async def receive() -> dict:
+        return next(messages)
+
+    with anyio.fail_after(2):
+        await app({"type": "lifespan", "asgi": {"version": "3.0"}, "state": {}}, receive, send)
+
+    types = [event["type"] for event in sent_events]
+    assert "lifespan.startup.failed" in types
+    # Never reported ready: the failing mount is not completed for on its way out
+    assert "lifespan.startup.complete" not in types
+    failure = next(e for e in sent_events if e["type"] == "lifespan.startup.failed")
+    assert failure["message"] == "no database"
+
+
 @pytest.mark.anyio
 async def test_dispatcher_denies_an_unmatched_websocket_with_404() -> None:
     """Where the server offers the denial response extension, say why - a 404.


### PR DESCRIPTION
A mount that said lifespan.startup.failed had that message dropped - nothing forwarded it - and was then completed for on its way out, since it had never acknowledged startup. A worker whose app had told it that it could not run therefore reported itself started, with no error anywhere.

Forward the failure, remember that the mount reported one, and do not complete for a mount that did. Declining lifespan - by raising, or by returning without acknowledging - is still treated as having none, which is a different thing and still covered.

Passing the failure on is itself what raises, since Lifespan.asgi_send turns lifespan.startup.failed into LifespanFailureError, and _run_mount's except Exception was swallowing that on the grounds that the mount had not started - leaving the server to wait out its startup timeout for an acknowledgement that was never coming. It now re-raises for a mount that failed, so the error reaches the server, arriving at the task group boundary exactly as it does for a failing app with no dispatcher in front of it.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK