### PR TITLE
Initialise HTTPStream.app_put

### DIFF
--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -9,6 +9,7 @@ from urllib.parse import unquote
 
 from anycorn.typing import (
     AppWrapper,
+    ASGIReceiveEvent,
     ASGISendEvent,
     ConnectionState,
     Extensions,
@@ -78,6 +79,9 @@ class HTTPStream:
     ) -> None:
         """Initialize the HTTP stream handler."""
         self.app = app
+        # Only set once a request has been spawned, and read on StreamClosed, which
+        # can arrive first if the connection dies during the spawn
+        self.app_put: Callable[[ASGIReceiveEvent], Awaitable[None]] | None = None
         self.client = client
         self.closed = False
         self.config = config
@@ -148,10 +152,13 @@ class HTTPStream:
                 self.closed = True
 
         elif isinstance(event, Body):
+            # A body cannot arrive before the request that opened the stream
+            assert self.app_put is not None
             await self.app_put(
                 {"type": "http.request", "body": bytes(event.data), "more_body": True}
             )
         elif isinstance(event, EndBody):
+            assert self.app_put is not None
             await self.app_put({"type": "http.request", "body": b"", "more_body": False})
         elif isinstance(event, StreamClosed):
             self.closed = True


### PR DESCRIPTION
It was only ever set once a request had been spawned, but StreamClosed reads it and can arrive first - the connection dying during the spawn is enough. The `is not None` guard there was already written as though it might be unset.

Annotating it made the type checker point at the two call sites that use it without a guard, where a body cannot arrive before the request that opened the stream; both now say so.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK