### PR TITLE
Do not close an HTTP stream that has not started a response

### DIFF
--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -250,7 +250,11 @@ class HTTPStream:
                     self.state = ASGIHTTPState.TRAILERS
                     break
 
-            if not message.get("more_trailers", False):
+            # Only once a response has actually been started. Without `te: trailers`
+            # the loop above sends nothing, and closing here read self.response, which
+            # is never assigned until a response starts - an app whose first message
+            # was trailers took an AttributeError instead of a reply.
+            if self.state == ASGIHTTPState.TRAILERS and not message.get("more_trailers", False):
                 await self._send_closed()
         elif (
             message["type"] == "http.response.trailers"

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -533,3 +533,28 @@ async def test_abnormal_close_logging() -> None:
             )
         )
         await stream.handle(StreamClosed(stream_id=1))
+
+
+@pytest.mark.anyio
+async def test_trailers_without_te_do_not_crash(stream: HTTPStream) -> None:
+    """Trailers as the first message, from a client that never asked for them.
+
+    Nothing is sent - the client did not offer `te: trailers` - but closing the
+    stream here used to read self.response, which no response had yet assigned,
+    so the app got an AttributeError rather than a reply.
+    """
+    await stream.handle(
+        Request(
+            stream_id=1,
+            http_version="2",
+            headers=[],  # no te: trailers
+            raw_path=b"/",
+            method="GET",
+            state=ConnectionState({}),
+        )
+    )
+
+    await stream.app_send({"type": "http.response.trailers", "headers": [(b"x", b"y")]})
+
+    # Still awaiting a response rather than closed, so the app can go on to send one
+    assert stream.state == ASGIHTTPState.REQUEST


### PR DESCRIPTION
An app whose first message is http.response.trailers, from a client that never sent te: trailers, sends nothing - the loop looking for that header matches none. Closing the stream regardless read self.response, which no response had assigned, so the app got AttributeError instead of a reply.

Close only once a response is actually under way. An app that then sends nothing more still gets the 500 that a silent app has always got.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK