### PR TITLE
Give a port-less server a port in the WSGI environ

### DIFF
--- a/src/anycorn/app_wrappers.py
+++ b/src/anycorn/app_wrappers.py
@@ -28,6 +28,10 @@ class _SupportsClose(Protocol):
     def close(self) -> None: ...
 
 
+HTTP_PORT = 80
+HTTPS_PORT = 443
+
+
 class InvalidPathError(Exception):
     """Raised when the request path is invalid."""
 
@@ -199,7 +203,10 @@ def _build_environ(scope: HTTPScope, body: bytes) -> dict:
         "SERVER_NAME": server[0],
         # PEP 3333 requires every CGI-style environ value to be a native string;
         # a WSGI app doing environ["SERVER_PORT"] + something breaks on a raw int.
-        "SERVER_PORT": str(server[1]),
+        # A server with no port - which ASGI allows, and which str() would render
+        # as the word "None" - takes the default for its scheme, so that an app
+        # rebuilding the request URL gets one that parses.
+        "SERVER_PORT": str(server[1] if server[1] is not None else _default_port(scope)),
         "SERVER_PROTOCOL": f"HTTP/{scope['http_version']}",
         "wsgi.version": (1, 0),
         "wsgi.url_scheme": scope.get("scheme", "http"),
@@ -228,3 +235,8 @@ def _build_environ(scope: HTTPScope, body: bytes) -> dict:
             value = environ[corrected_name] + "," + value  # type: ignore[operator,assignment]
         environ[corrected_name] = value
     return environ
+
+
+def _default_port(scope: HTTPScope) -> int:
+    """Return the port a URL of this scheme implies when the server has none."""
+    return HTTPS_PORT if scope.get("scheme") == "https" else HTTP_PORT

--- a/tests/test_app_wrappers.py
+++ b/tests/test_app_wrappers.py
@@ -438,3 +438,39 @@ def test_build_environ_root_path() -> None:
     }
     with pytest.raises(InvalidPathError):
         _build_environ(scope, b"")
+
+
+@pytest.mark.parametrize(
+    ("scheme", "server", "expected"),
+    [
+        ("http", ("example.com", 8000), "8000"),
+        # ASGI allows a server with no port - a unix socket. str() rendered that as
+        # the word "None", which an app rebuilding the request URL cannot use.
+        ("http", ("/run/anycorn.sock", None), "80"),
+        ("https", ("/run/anycorn.sock", None), "443"),
+        # No server at all already fell back, and still does
+        ("http", None, "80"),
+    ],
+)
+def test_build_environ_server_port_is_always_a_usable_string(
+    scheme: str, server: tuple | None, expected: str
+) -> None:
+    environ = _build_environ(
+        cast(
+            "HTTPScope",
+            {
+                "method": "GET",
+                "path": "/",
+                "root_path": "",
+                "query_string": b"",
+                "headers": [],
+                "http_version": "1.1",
+                "scheme": scheme,
+                "server": server,
+            },
+        ),
+        b"",
+    )
+    assert environ["SERVER_PORT"] == expected
+    # A native string PEP 3333 calls for, and one an app can act on
+    assert int(environ["SERVER_PORT"]) > 0


### PR DESCRIPTION
_build_environ rendered a server with no port as the string "None", which an app rebuilding the request URL cannot use. ASGI allows that shape for a unix socket, so take the scheme's default port instead.

Note anycorn does not produce it today - parse_socket_addr returns None for AF_UNIX, so the existing ("localhost", 80) fallback covers a unix bind - but the scope type allows it and middleware can set it.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK