### PR TITLE
Discard an HTTP/2 stream's send state when the peer resets it

### DIFF
--- a/src/anycorn/protocol/h2.py
+++ b/src/anycorn/protocol/h2.py
@@ -201,9 +201,7 @@ class H2Protocol:
         except (h2.exceptions.StreamClosedError, KeyError, h2.exceptions.ProtocolError):
             # Stream or connection has closed whilst waiting to send
             # data, not a problem - just force close it.
-            await self.stream_buffers[stream_id].close()
-            del self.stream_buffers[stream_id]
-            self.priority.remove_stream(stream_id)
+            await self._discard_send_state(stream_id)
 
     async def handle(self, event: Event) -> None:
         """Handle an incoming connection event."""
@@ -297,6 +295,11 @@ class H2Protocol:
                     await self.streams[event.stream_id].handle(EndBody(stream_id=event.stream_id))
             elif isinstance(event, h2.events.StreamReset):
                 await self._close_stream(event.stream_id)
+                # The send side is tracked apart from self.streams and is only tidied
+                # up by _send_data once a response finishes. A reset stream never gets
+                # there, so its buffer and its place in the priority tree would
+                # outlive it, for the life of the connection.
+                await self._discard_send_state(event.stream_id)
                 await self._window_updated(event.stream_id)
             elif isinstance(event, h2.events.WindowUpdated):
                 await self._window_updated(event.stream_id)
@@ -429,3 +432,11 @@ class H2Protocol:
             stream = self.streams.pop(stream_id)
             await stream.handle(StreamClosed(stream_id=stream_id))
             await self.has_data.set()
+
+    async def _discard_send_state(self, stream_id: int) -> None:
+        """Drop a stream's send buffer and priority entry, however often it is called."""
+        buffer = self.stream_buffers.pop(stream_id, None)
+        if buffer is not None:
+            await buffer.close()
+        with contextlib.suppress(priority.MissingStreamError):
+            self.priority.remove_stream(stream_id)

--- a/tests/protocol/test_h2.py
+++ b/tests/protocol/test_h2.py
@@ -161,3 +161,46 @@ async def test_stream_send_trailers_ends_stream() -> None:
         await protocol.stream_send(Trailers(stream_id=1, headers=[(b"x", b"y")]))
 
     protocol.connection.send_headers.assert_called_once_with(1, [(b"x", b"y")], end_stream=True)
+
+
+@pytest.mark.anyio
+async def test_reset_stream_does_not_leak_send_state() -> None:
+    """A reset stream must not leave its send buffer and priority entry behind.
+
+    Only _send_data tidies those up, and only once a response has finished. A
+    stream the peer resets never gets there, so on a long-lived connection - a
+    browser cancelling requests, say - both grew without bound.
+    """
+    protocol = H2Protocol(
+        Mock(),
+        Config(),
+        WorkerContext(None),
+        AsyncMock(),
+        ConnectionState({}),
+        None,
+        None,
+        AsyncMock(),
+        None,
+    )
+    client = H2Connection()
+    client.initiate_connection()
+    client.send_headers(
+        1,
+        [
+            (b":method", b"POST"),
+            (b":path", b"/"),
+            (b":authority", b"anycorn"),
+            (b":scheme", b"https"),
+        ],
+        end_stream=False,
+    )
+    await protocol.handle(RawData(data=client.data_to_send()))
+    assert 1 in protocol.stream_buffers
+    assert 1 in protocol.priority._streams
+
+    client.reset_stream(1)
+    await protocol.handle(RawData(data=client.data_to_send()))
+
+    assert protocol.streams == {}
+    assert protocol.stream_buffers == {}
+    assert 1 not in protocol.priority._streams


### PR DESCRIPTION
A stream's send buffer and its place in the priority tree are tracked apart from self.streams, and are only tidied up by _send_data once a response finishes. A stream the peer resets never reaches that, so both outlived it for the life of the connection - unbounded growth on a connection whose client cancels requests, which browsers do routinely.

The cleanup deliberately does not go in _close_stream, which is also the normal completion path: discarding a buffer there truncates a response send_task has not flushed yet, which the h2 multiplexing and state-isolation tests catch.

It is shared with _send_data's own error path, which re-indexed the dict it was handling a KeyError for and would itself have raised; it is now idempotent, so either path can run first.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK