### PR TITLE
Resume a paused HTTP/2 writer on what has drained, not what was taken

### DIFF
--- a/src/anycorn/protocol/h2.py
+++ b/src/anycorn/protocol/h2.py
@@ -93,7 +93,12 @@ class StreamBuffer:
         length = min(len(self.buffer), max_length)
         data = bytes(self.buffer[:length])
         del self.buffer[:length]
-        if len(data) < BUFFER_LOW_WATER:
+        # On what is left, not on what was taken. Keying this on the size of the
+        # chunk popped let a zero-length pop - which is what _send_data does once
+        # the peer's flow control window is exhausted - release the writer with the
+        # buffer still above the high water mark, so the marks did not mean what
+        # they say.
+        if len(self.buffer) < BUFFER_LOW_WATER:
             await self._paused.set()
         if len(self.buffer) == 0:
             await self._is_empty.set()

--- a/tests/protocol/test_h2.py
+++ b/tests/protocol/test_h2.py
@@ -30,6 +30,12 @@ except ImportError:
 
 @pytest.mark.anyio
 async def test_stream_buffer_push_and_pop() -> None:
+    """The writer resumes once the buffer has drained, not once a chunk is taken.
+
+    Resuming on the size of the chunk popped meant a zero-length pop - which is
+    what _send_data does once the peer's flow control window is exhausted - let
+    the writer on with the buffer still above the high water mark.
+    """
     stream_buffer = StreamBuffer(EventWrapper)
     pushed = False
 
@@ -43,9 +49,20 @@ async def test_stream_buffer_push_and_pop() -> None:
         await anyio.wait_all_tasks_blocked()
         assert not pushed  # Blocked as over high water
 
+        # Nothing could be sent, so nothing has drained and the writer stays put
+        await stream_buffer.pop(0)
+        await anyio.wait_all_tasks_blocked()
+        assert not pushed
+
+        # Drained some, but not to below the low water mark
         await stream_buffer.pop(BUFFER_HIGH_WATER // 4)
         await anyio.wait_all_tasks_blocked()
-        assert pushed  # Resumed, as the pop was under low water
+        assert not pushed
+
+        # Now under it, so there is room for the writer to go on
+        await stream_buffer.pop(BUFFER_HIGH_WATER)
+        await anyio.wait_all_tasks_blocked()
+        assert pushed
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
StreamBuffer.pop released the writer when the chunk it popped was under the low water mark, rather than when the buffer had drained under it. _send_data pops whatever the peer's flow control window allows, and that window is zero once a peer stops reading - so a zero-length pop, having sent nothing, let the writer straight back in with the buffer still above the high water mark. Driving a real H2Protocol with an exhausted window showed the app released with all 32769 bytes still buffered.

Growth was bounded, since the next push re-checks and re-pauses, so this is churn and a needlessly woken writer rather than a leak. But the marks did not mean what they say.

The existing test asserted the behaviour being removed - it popped a quarter of the buffer and expected the writer to resume - so it now walks the three cases that distinguish the two rules: nothing drained, some drained but still above the mark, and drained below it.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK