### PR TITLE
Refuse a redirect target the client wrote

### DIFF
--- a/src/anycorn/middleware/http_to_https.py
+++ b/src/anycorn/middleware/http_to_https.py
@@ -10,6 +10,11 @@ if TYPE_CHECKING:
 
     from anycorn.typing import ASGIFramework, HTTPScope, Scope, WebsocketScope, WWWScope
 
+# Longest a DNS name can be, so a header beyond it is not one
+MAX_HOST_LENGTH = 255
+# Below this a byte is a control character, which no host name carries
+FIRST_PRINTABLE = 0x20
+
 
 class HTTPToHTTPSRedirectMiddleware:
     """ASGI middleware that issues 307 redirects from HTTP/WS to HTTPS/WSS."""
@@ -36,6 +41,18 @@ class HTTPToHTTPSRedirectMiddleware:
 
     async def _send_http_redirect(self, scope: HTTPScope, send: Callable) -> None:
         new_url = self._new_url("https", scope)
+        if new_url is None:
+            # The request said where to send it and the answer was unusable, which
+            # is the client's mistake to hear about - not a server error.
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 400,
+                    "headers": [(b"content-length", b"0")],
+                }
+            )
+            await send({"type": "http.response.body"})
+            return
         await send(
             {
                 "type": "http.response.start",
@@ -53,6 +70,16 @@ class HTTPToHTTPSRedirectMiddleware:
             scheme = "https"
 
         new_url = self._new_url(scheme, scope)
+        if new_url is None:
+            await send(
+                {
+                    "type": "websocket.http.response.start",
+                    "status": 400,
+                    "headers": [(b"content-length", b"0")],
+                }
+            )
+            await send({"type": "websocket.http.response.body"})
+            return
         await send(
             {
                 "type": "websocket.http.response.start",
@@ -62,16 +89,39 @@ class HTTPToHTTPSRedirectMiddleware:
         )
         await send({"type": "websocket.http.response.body"})
 
-    def _new_url(self, scheme: str, scope: WWWScope) -> str:
+    def _new_url(self, scheme: str, scope: WWWScope) -> str | None:
+        """Return the URL to redirect to, or None if the request does not admit one."""
         host = self.host
         if host is None:
             for key, value in scope["headers"]:
                 if key == b"host":
                     host = value.decode("latin-1")
                     break
+            if host is not None and not _is_bare_host(host):
+                # The header is the client's to write, and it lands in the netloc of
+                # a URL this server hands back as a redirect. Anything but a bare
+                # host[:port] there grafts a target of the client's choosing onto the
+                # response - a Host of "example.com/elsewhere" redirects to
+                # https://example.com/elsewhere rather than to this site.
+                return None
         if host is None:
             msg = "Host to redirect to cannot be determined"
             raise ValueError(msg)
 
         path = scope.get("root_path", "") + scope["raw_path"].decode()
         return urlunsplit((scheme, host, path, scope["query_string"].decode(), ""))
+
+
+def _is_bare_host(host: str) -> bool:
+    """Return True when *host* is a host[:port] and nothing more.
+
+    Only the shape is checked. Whether the name is one this server answers to is a
+    separate question, and one this middleware cannot answer: pass *host* to pin the
+    redirect target, or set `server_names` so a request carrying any other Host is
+    turned away before it reaches an app at all.
+    """
+    if not host or len(host) > MAX_HOST_LENGTH:
+        return False
+    return not any(char in host for char in "/\\?#@") and all(
+        not char.isspace() and ord(char) >= FIRST_PRINTABLE for char in host
+    )

--- a/tests/middleware/test_http_to_https.py
+++ b/tests/middleware/test_http_to_https.py
@@ -175,3 +175,86 @@ def test_http_to_https_redirect_new_url_header() -> None:
         ),
     )
     assert new_url == "https://localhost/"
+
+
+def _scope_with_host(host: bytes) -> HTTPScope:
+    return HTTPScope(
+        http_version="1.1",
+        asgi={},
+        method="GET",
+        headers=[(b"host", host)],
+        path="/",
+        root_path="",
+        query_string=b"",
+        raw_path=b"/",
+        scheme="http",
+        type="http",
+        client=None,
+        server=None,
+        extensions={},
+        state=ConnectionState({}),
+    )
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        b"example.com/elsewhere",  # grafts a path onto the target
+        b"example.com\\elsewhere",  # the same, as some clients normalise backslashes
+        b"user@example.com",  # userinfo, so the real host is what follows the @
+        b"example.com?x=y",
+        b"example.com#fragment",
+        b"example.com ",
+        b"",
+    ],
+)
+def test_new_url_refuses_a_host_header_that_is_not_a_bare_host(host: bytes) -> None:
+    """The Host header is the client's to write, and it lands in the redirect target.
+
+    Anything but a bare host[:port] there lets a client choose where this server
+    sends it - a Host of "example.com/elsewhere" redirected to
+    https://example.com/elsewhere rather than back to this site.
+    """
+    app = HTTPToHTTPSRedirectMiddleware(empty_framework, None)
+
+    assert app._new_url("https", _scope_with_host(host)) is None
+
+
+@pytest.mark.parametrize(
+    "host", [b"example.com", b"example.com:8443", b"127.0.0.1:80", b"[::1]:80"]
+)
+def test_new_url_accepts_a_bare_host(host: bytes) -> None:
+    """A plain host, with or without a port, is still used as before."""
+    app = HTTPToHTTPSRedirectMiddleware(empty_framework, None)
+
+    assert app._new_url("https", _scope_with_host(host)) == f"https://{host.decode()}/"
+
+
+def test_new_url_prefers_the_configured_host() -> None:
+    """A pinned host is what makes this immune, and it is not second-guessed."""
+    app = HTTPToHTTPSRedirectMiddleware(empty_framework, "pinned.example")
+
+    assert app._new_url("https", _scope_with_host(b"attacker.example")) == "https://pinned.example/"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("host", "status"),
+    [(b"example.com", b"307"), (b"[::1]:8080", b"307"), (b"example.com/evil", b"400")],
+)
+async def test_redirect_answers_an_unusable_host_with_400(host: bytes, status: bytes) -> None:
+    """A Host that cannot be redirected to is the client's mistake, so 400 not 500.
+
+    Refusing by raising surfaced as a 500, which reads as the server having broken
+    and puts a client-supplied header into the error log of every deployment behind
+    a scanner.
+    """
+    sent_events = []
+
+    async def send(message: dict) -> None:
+        sent_events.append(message)
+
+    app = HTTPToHTTPSRedirectMiddleware(empty_framework, None)
+    await app(_scope_with_host(host), None, send)  # type: ignore[arg-type]
+
+    assert b"%d" % sent_events[0]["status"] == status


### PR DESCRIPTION
HTTPToHTTPSRedirectMiddleware put the Host header straight into the netloc of the URL it redirects to. Anything but a bare host[:port] there picks the target: a Host of "example.com/elsewhere" sent the client to https://example.com/elsewhere rather than back to this site, and a userinfo "@" moves the real host past it. Check the shape, and answer 400 rather than redirect somewhere a request asked to go - the client's mistake to hear about, not a server error.

Only the shape. Whether a name is one this server answers to is a question this middleware cannot answer - pass host= to pin the target, or set server_names so a request carrying any other Host never reaches an app. Both are noted where the check lives. A Host that cannot be found at all still raises, since that is a server with nothing to redirect to rather than a request to turn away.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK