### PR TITLE
Copy the scope shallowly in ProxyFixMiddleware

### DIFF
--- a/src/anycorn/middleware/proxy_fix.py
+++ b/src/anycorn/middleware/proxy_fix.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -28,7 +27,11 @@ class ProxyFixMiddleware:
         """Process the ASGI scope and apply proxy header rewrites before passing to the app."""
         # Keep the `or` instead of `in {'http' …}` to allow type narrowing
         if scope["type"] == "http" or scope["type"] == "websocket":
-            scope = deepcopy(scope)
+            # Shallow: only client, scheme and headers are replaced, and headers is
+            # rebuilt as a new list rather than mutated. A deepcopy also copied
+            # scope["state"], which carries whatever lifespan put there - a database
+            # pool, a client, a lock - and raised TypeError on anything unpicklable.
+            scope = scope.copy()
             headers = scope["headers"]
             client: str | None = None
             scheme: str | None = None

--- a/tests/middleware/test_proxy_fix.py
+++ b/tests/middleware/test_proxy_fix.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import threading
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 
 import pytest
 
 from anycorn.middleware import ProxyFixMiddleware
 from anycorn.typing import ConnectionState, HTTPScope
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @pytest.mark.anyio
@@ -73,3 +78,35 @@ async def test_proxy_fix_modern() -> None:
     assert scope["scheme"] == "https"
     host_headers = [h for h in scope["headers"] if h[0].lower() == b"host"]
     assert host_headers == [(b"host", b"example.com")]
+
+
+@pytest.mark.anyio
+async def test_proxy_fix_keeps_unpicklable_state() -> None:
+    """The scope carries whatever lifespan put in state, which need not be copyable.
+
+    A deepcopy of the whole scope raised TypeError on anything unpicklable - a
+    database pool, a client, a lock - so every request through this middleware
+    failed. Only client, scheme and headers are rewritten, so a shallow copy does.
+    """
+    lock = threading.Lock()
+    state = {"pool": lock}
+    seen: list[Any] = []
+
+    async def app(scope: Any, _receive: Callable, _send: Callable) -> None:  # noqa: ANN401
+        seen.append(scope)
+
+    scope = {
+        "type": "http",
+        "headers": [(b"x-forwarded-for", b"127.0.0.1")],
+        "client": ("localhost", 80),
+        "scheme": "http",
+        "state": state,
+    }
+
+    await ProxyFixMiddleware(app, mode="legacy").__call__(scope, AsyncMock(), AsyncMock())  # type: ignore[arg-type]
+
+    # Handed on, not copied: the app sees the very object lifespan created
+    assert seen[0]["state"]["pool"] is lock
+    # And the caller's scope was left alone
+    assert scope["client"] == ("localhost", 80)
+    assert seen[0]["client"] == ("127.0.0.1", 0)


### PR DESCRIPTION
It deep-copied the whole scope, including the state lifespan fills with pools, clients and locks, so any unpicklable value there made every request through it raise TypeError: cannot pickle '_thread.lock' object. Only client, scheme and headers are rewritten, and headers is rebuilt as a new list, so a shallow copy does - and the app keeps the state object lifespan gave it.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK