### PR TITLE
Do not read a websocket response that never started

### DIFF
--- a/src/anycorn/protocol/ws_stream.py
+++ b/src/anycorn/protocol/ws_stream.py
@@ -225,7 +225,9 @@ class WSStream:
         self.config = config
         self.context = context
         self.task_group = task_group
-        self.response: WebsocketResponseStartEvent
+        # Only set once the app starts a denial response; a body may arrive
+        # without one, which is the app's mistake rather than a crash here
+        self.response: WebsocketResponseStartEvent | None = None
         self.scope: WebsocketScope
         self.send = send
         self.server = server
@@ -327,10 +329,18 @@ class WSStream:
             and self.state == ASGIWebsocketState.HANDSHAKE
         ):
             self.response = message
-        elif message["type"] == "websocket.http.response.body" and self.state in {
-            ASGIWebsocketState.HANDSHAKE,
-            ASGIWebsocketState.RESPONSE,
-        }:
+        elif (
+            message["type"] == "websocket.http.response.body"
+            and self.state
+            in {
+                ASGIWebsocketState.HANDSHAKE,
+                ASGIWebsocketState.RESPONSE,
+            }
+            # Without a response having started there is no status to send this
+            # body with, and reading one raised AttributeError. Fall through to
+            # the unexpected-message error the app deserves instead.
+            and self.response is not None
+        ):
             await self._send_rejection(message)
         elif message["type"] == "websocket.send" and self.state == ASGIWebsocketState.CONNECTED:
             event: WSProtoEvent
@@ -420,6 +430,8 @@ class WSStream:
             self.task_group.spawn(self._send_pings)
 
     async def _send_rejection(self, message: WebsocketResponseBodyEvent) -> None:
+        # Guaranteed by app_send, which only routes here once a response has started
+        assert self.response is not None
         body_suppressed = suppress_body("GET", self.response["status"])
         if self.state == ASGIWebsocketState.HANDSHAKE:
             headers = build_and_validate_headers(self.response["headers"])

--- a/tests/protocol/test_ws_stream.py
+++ b/tests/protocol/test_ws_stream.py
@@ -665,3 +665,34 @@ async def test_closed_app_send_noop(stream: WSStream) -> None:
     stream.closed = True
     await stream.app_send(cast("WebsocketAcceptEvent", {"type": "websocket.accept"}))
     stream.send.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_rejection_body_without_a_response_start(stream: WSStream) -> None:
+    """A denial body with no response started is the app's error, not a crash.
+
+    The status to send it with comes from the response start that never arrived,
+    and reading it raised AttributeError - so an app that sent the body first got
+    that instead of the unexpected-message error describing what it did wrong.
+    """
+    await stream.handle(
+        Request(
+            stream_id=1,
+            http_version="1.1",
+            method="GET",
+            raw_path=b"/",
+            state=ConnectionState({}),
+            headers=[
+                (b"host", b"anycorn"),
+                (b"connection", b"Upgrade"),
+                (b"upgrade", b"WebSocket"),
+                (b"sec-websocket-version", b"13"),
+                (b"sec-websocket-key", b"ZGVtbw=="),
+            ],
+        )
+    )
+
+    with pytest.raises(UnexpectedMessageError):
+        await stream.app_send(
+            {"type": "websocket.http.response.body", "body": b"denied", "more_body": False}
+        )


### PR DESCRIPTION
WSStream._send_rejection read self.response as its first statement, and app_send routed a websocket.http.response.body there whilst still in the handshake - exactly the state where no response start has arrived and self.response is only ever declared. An app sending the denial body before its start got AttributeError rather than the unexpected-message error that says what it did wrong.

Require a started response to route there, so such a body falls through to that error instead.


Claude-Session: https://claude.ai/code/session_01Lj1kTdm3gz4JB3bjeygDaK