### PR TITLE
Add option to match dispatcher mounts on a path segment boundary

### DIFF
--- a/src/anycorn/middleware/dispatcher.py
+++ b/src/anycorn/middleware/dispatcher.py
@@ -18,15 +18,16 @@ MAX_QUEUE_SIZE = 10
 
 
 class _DispatcherMiddleware:
-    def __init__(self, mounts: dict[str, ASGIFramework]) -> None:
+    def __init__(self, mounts: dict[str, ASGIFramework], *, strict_paths: bool = False) -> None:
         self.mounts = mounts
+        self.strict_paths = strict_paths
 
     async def __call__(self, scope: Scope, receive: Callable, send: Callable) -> None:
         if scope["type"] == "lifespan":
             await self._handle_lifespan(scope, receive, send)
         else:
             for path, app in self.mounts.items():
-                if scope["path"].startswith(path):
+                if self._mounted_at(scope["path"], path):
                     local_scope = scope.copy()
                     local_scope["root_path"] = local_scope.get("root_path", "") + path
                     return await app(local_scope, receive, send)
@@ -62,6 +63,20 @@ class _DispatcherMiddleware:
             await send({"type": "websocket.http.response.body"})
         else:
             await send({"type": "websocket.close"})
+
+    def _mounted_at(self, path: str, mount: str) -> bool:
+        """Return True when *path* belongs to the app mounted at *mount*.
+
+        Matching on any shared prefix, which is what this does by default, lets a
+        /foo mount swallow /foobar - leaving a /foobar mount unreachable, and
+        handing /foo a root_path it never served. strict_paths matches on a path
+        segment boundary instead, so each mount gets only what is under it. It is
+        opt-in because the prefix behaviour is what callers have been routed by so
+        far, and a mount relying on it would stop being reached.
+        """
+        if not self.strict_paths:
+            return path.startswith(mount)
+        return path == mount or path.startswith(mount.rstrip("/") + "/")
 
     async def _handle_lifespan(self, scope: Scope, receive: Callable, send: Callable) -> None:
         pass

--- a/tests/middleware/test_dispatcher.py
+++ b/tests/middleware/test_dispatcher.py
@@ -189,3 +189,67 @@ async def test_dispatcher_closes_an_unmatched_websocket_without_the_extension() 
     await app(scope, AsyncMock(), send)  # type: ignore[arg-type]
 
     assert [message["type"] for message in sent] == ["websocket.close"]
+
+
+def _recording_mounts(served: list[tuple[str, str]]) -> Callable:
+    def _mount(name: str) -> Callable:
+        async def _app(scope: HTTPScope, _receive: Callable, send: Callable) -> None:
+            served.append((name, scope["root_path"]))
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+
+        return _app
+
+    return _mount
+
+
+@pytest.mark.anyio
+async def test_strict_paths_matches_on_a_path_boundary(http_scope: HTTPScope) -> None:
+    """With strict_paths a /foo mount must not swallow /foobar, which has its own."""
+    served: list[tuple[str, str]] = []
+    _mount = _recording_mounts(served)
+    app = DispatcherMiddleware(
+        {"/foo": _mount("foo"), "/foobar": _mount("foobar")}, strict_paths=True
+    )
+
+    for path, expected in (("/foobar", "foobar"), ("/foo", "foo"), ("/foo/deeper", "foo")):
+        scope = dict(http_scope)
+        scope["path"] = path
+        scope["root_path"] = ""
+        await app(scope, AsyncMock(), AsyncMock())  # type: ignore[arg-type]
+        assert served[-1][0] == expected, f"{path} went to {served[-1][0]}"
+
+
+@pytest.mark.anyio
+async def test_prefix_matching_is_still_the_default(http_scope: HTTPScope) -> None:
+    """Left alone, mounts still match on any shared prefix.
+
+    Which is what routes callers today, so a mount relying on it keeps being
+    reached; strict_paths is how the boundary behaviour is asked for.
+    """
+    served: list[tuple[str, str]] = []
+    _mount = _recording_mounts(served)
+    app = DispatcherMiddleware({"/foo": _mount("foo"), "/foobar": _mount("foobar")})
+
+    scope = dict(http_scope)
+    scope["path"] = "/foobar"
+    scope["root_path"] = ""
+    await app(scope, AsyncMock(), AsyncMock())  # type: ignore[arg-type]
+
+    assert served == [("foo", "/foo")]
+
+
+@pytest.mark.anyio
+async def test_strict_paths_still_lets_a_root_mount_match_everything(
+    http_scope: HTTPScope,
+) -> None:
+    """A "/" mount is a prefix of every path, and stays one under strict_paths."""
+    served: list[tuple[str, str]] = []
+    app = DispatcherMiddleware({"/": _recording_mounts(served)("root")}, strict_paths=True)
+
+    scope = dict(http_scope)
+    scope["path"] = "/anything/at/all"
+    scope["root_path"] = ""
+    await app(scope, AsyncMock(), AsyncMock())  # type: ignore[arg-type]
+
+    assert served == [("root", "/")]


### PR DESCRIPTION
DispatcherMiddleware matches a mount against any shared path prefix, so a
/foo mount swallows /foobar - leaving a /foobar mount unreachable, and
handing /foo a root_path it never served.

Matching on a path segment boundary instead is opt-in via strict_paths,
since prefix matching is what has routed callers so far and a mount
relying on it would otherwise stop being reached. The default is
unchanged.