### PR TITLE
Restore umask if binding a unix socket fails

### DIFF
--- a/src/anycorn/config.py
+++ b/src/anycorn/config.py
@@ -318,14 +318,19 @@ class Config:
             _set_reuse_socket_option(sock)
 
             if bind.startswith("unix:"):
+                assert binding is not None
+                # os.umask changes process-global state, so restore it in a finally:
+                # a bind() or chown() that raises would otherwise leave the worker's
+                # umask altered for every later socket and file it creates.
                 if self.umask is not None:
                     current_umask = os.umask(self.umask)
-                assert binding is not None
-                sock.bind(binding)
-                if self.user is not None and self.group is not None:
-                    os.chown(binding, self.user, self.group)  # type: ignore[attr-defined]
-                if self.umask is not None:
-                    os.umask(current_umask)
+                try:
+                    sock.bind(binding)
+                    if self.user is not None and self.group is not None:
+                        os.chown(binding, self.user, self.group)  # type: ignore[attr-defined]
+                finally:
+                    if self.umask is not None:
+                        os.umask(current_umask)
             elif bind.startswith("fd://"):
                 pass
             else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,6 +133,33 @@ def test_create_sockets_unix(monkeypatch: MonkeyPatch) -> None:
     sock.set_inheritable.assert_called_with(True)  # type: ignore[attr-defined]  # noqa: FBT003
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows is not Unix.")
+def test_create_sockets_unix_restores_umask_on_bind_failure(monkeypatch: MonkeyPatch) -> None:
+    """A failed bind must not leak the configured umask into the rest of the process."""
+    mock_socket = Mock()
+    mock_socket.return_value.bind.side_effect = OSError("bind failed")
+    monkeypatch.setattr(socket, "socket", mock_socket)
+
+    umask_calls: list[int] = []
+
+    def fake_umask(mask: int) -> int:
+        umask_calls.append(mask)
+        return 0o22
+
+    monkeypatch.setattr(os, "umask", fake_umask)
+
+    config = Config()
+    config.umask = 0o077
+    config.bind = ["unix:/tmp/anycorn.sock"]
+
+    with pytest.raises(OSError, match="bind failed"):
+        config.create_sockets()
+
+    # The configured umask is applied, then restored to what os.umask returned even
+    # though bind() raised in between.
+    assert umask_calls == [0o077, 0o22]
+
+
 def test_create_sockets_fd(monkeypatch: MonkeyPatch) -> None:
     mock_sock_class = Mock(
         return_value=NonCallableMock(**{"getsockopt.return_value": socket.SOCK_STREAM})  # type: ignore[arg-type]


### PR DESCRIPTION
_create_sockets set the configured umask with os.umask before binding a unix socket and restored it afterwards, but a bind() or chown() that raised in between skipped the restore. os.umask is process-global, so the worker was left with the altered umask for every socket and file it created thereafter.

Move the set/restore into a try/finally so the previous umask is always restored, even when binding fails.


Claude-Session: https://claude.ai/code/session_011Fcnjz9Dicw52pye2Ga22o