### PR TITLE
Serialise lazy statsd socket creation

### DIFF
--- a/src/anycorn/statsd.py
+++ b/src/anycorn/statsd.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import anyio
+
 from .datagram import DatagramSocket, connect_datagram_socket
 from .logging import Logger
 
@@ -122,10 +124,18 @@ class StatsdLogger(BaseStatsdLogger):
         assert config.statsd_host is not None
         self.address = tuple(config.statsd_host.rsplit(":", 1))
         self._sender: DatagramSocket | None = None
+        self._sender_lock = anyio.Lock()
 
     async def _socket_send(self, message: bytes) -> None:
         if self._sender is None:
-            self._sender = await connect_datagram_socket(self.address[0], int(self.address[1]))
+            # Guard the lazy open: without the lock two coroutines emitting their
+            # first metric concurrently would each open a socket, orphaning all but
+            # one (the checkpoint in connect_datagram_socket lets them interleave).
+            async with self._sender_lock:
+                if self._sender is None:
+                    self._sender = await connect_datagram_socket(
+                        self.address[0], int(self.address[1])
+                    )
 
         await self._sender.send(message)
 

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import socket
 
 import anyio
+import anyio.lowlevel
 import pytest
 from anyio.abc import SocketAttribute
 
@@ -54,6 +55,41 @@ async def test_metrics_survive_a_daemon_that_is_not_listening() -> None:
             await anyio.sleep(0.01)
     finally:
         await logger.aclose()
+
+
+@pytest.mark.anyio
+async def test_concurrent_first_sends_open_one_socket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two coroutines emitting their first metric together must share one socket.
+
+    The lazy open awaits, so without a lock both callers pass the ``is None`` check
+    and each open a socket, orphaning all but one.
+    """
+    opened = 0
+
+    class _FakeSender:
+        async def send(self, message: bytes) -> None:
+            pass
+
+        async def aclose(self) -> None:
+            pass
+
+    async def fake_connect(_host: str, _port: int) -> _FakeSender:
+        nonlocal opened
+        opened += 1
+        await anyio.lowlevel.checkpoint()  # checkpoint: lets a second caller interleave
+        return _FakeSender()
+
+    monkeypatch.setattr("anycorn.statsd.connect_datagram_socket", fake_connect)
+
+    config = Config()
+    config.statsd_host = "127.0.0.1:9125"
+    logger = StatsdLogger(config)
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(logger.increment, "anycorn.a", 1)
+        task_group.start_soon(logger.increment, "anycorn.b", 1)
+
+    assert opened == 1
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
StatsdLogger._socket_send opened its UDP socket lazily on the first metric, but the check-then-open straddled an await. Two coroutines emitting their first metric concurrently could both see self._sender as None and each open a socket, leaving all but one orphaned (never closed by aclose).

Guard the lazy open with an anyio.Lock and re-check under it so only one socket is ever created.


Claude-Session: https://claude.ai/code/session_011Fcnjz9Dicw52pye2Ga22o