### PR TITLE
Preserve hardened SSL options when disabling compression

### DIFF
--- a/src/anycorn/config.py
+++ b/src/anycorn/config.py
@@ -231,7 +231,11 @@ class Config:
         context = create_default_context(Purpose.CLIENT_AUTH)
         context.set_ciphers(self.ciphers)
         context.minimum_version = TLSVersion.TLSv1_2  # RFC 7540 Section 9.2: MUST be TLS >=1.2
-        context.options = OP_NO_COMPRESSION  # RFC 7540 Section 9.2.1: MUST disable compression
+        # OR the flag in rather than assigning it: create_default_context already sets
+        # hardened options (OP_CIPHER_SERVER_PREFERENCE, OP_SINGLE_DH_USE, OP_NO_TICKET,
+        # ...) and a plain assignment would clear them all, leaving only compression
+        # disabled. RFC 7540 Section 9.2.1: MUST disable compression.
+        context.options |= OP_NO_COMPRESSION
         context.set_alpn_protocols(self.alpn_protocols)
 
         if self.certfile is not None and self.keyfile is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,14 +70,16 @@ def test_create_ssl_context() -> None:
     context = config.create_ssl_context()
 
     assert context is not None
-    # create_ssl_context disables compression (RFC 7540 9.2.1) on top of the hardened
-    # options create_default_context() sets. Every option the default enables - which
-    # includes compression already being disabled - must survive, rather than being
-    # cleared by the step that disables compression. Deriving the expectation from a
-    # fresh default context covers the whole set without pinning a per-version list.
-    default_options = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH).options
-    missing = default_options & ~context.options
-    assert not missing, f"dropped hardening options: {ssl.Options(missing)!r}"
+    # The hardened options create_default_context() enables, plus OP_NO_COMPRESSION
+    # (RFC 7540 9.2.1). Asserting the exact set catches the earlier bug where assigning
+    # OP_NO_COMPRESSION cleared everything else, and any future regression that drops one.
+    assert context.options == (
+        ssl.OP_ALL
+        | ssl.OP_CIPHER_SERVER_PREFERENCE
+        | ssl.OP_ENABLE_MIDDLEBOX_COMPAT
+        | ssl.OP_NO_COMPRESSION
+        | ssl.OP_NO_SSLv3
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,24 +69,13 @@ def test_create_ssl_context() -> None:
     config = Config.from_pyfile(path)
     context = config.create_ssl_context()
 
-    # NOTE: In earlier versions of python context.options is equal to <Options.OP_NO_COMPRESSION: 0>
-    #       hence the ANDing context.options with the specified ssl options results in
-    #       "<Options.OP_NO_COMPRESSION: 0>", which as a Boolean value, is False.
-    #
-    #       To overcome this, instead of checking that the result in True, we will check that it is
-    #        equal to "context.options".
     assert context is not None
-    assert (
-        context.options
-        & (
-            ssl.OP_NO_SSLv2
-            | ssl.OP_NO_SSLv3
-            | ssl.OP_NO_TLSv1
-            | ssl.OP_NO_TLSv1_1
-            | ssl.OP_NO_COMPRESSION
-        )
-        == context.options
-    )
+    # Compression is disabled (RFC 7540 9.2.1) ...
+    assert context.options & ssl.OP_NO_COMPRESSION
+    # ... and the hardened defaults from create_default_context() are preserved rather
+    # than clobbered by the assignment that disables compression.
+    assert context.options & ssl.OP_CIPHER_SERVER_PREFERENCE
+    assert context.options & ssl.OP_NO_SSLv3
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,10 +72,13 @@ def test_create_ssl_context() -> None:
     assert context is not None
     # Compression is disabled (RFC 7540 9.2.1) ...
     assert context.options & ssl.OP_NO_COMPRESSION
-    # ... and the hardened defaults from create_default_context() are preserved rather
-    # than clobbered by the assignment that disables compression.
-    assert context.options & ssl.OP_CIPHER_SERVER_PREFERENCE
-    assert context.options & ssl.OP_NO_SSLv3
+    # ... and every hardening option create_default_context() sets is preserved rather
+    # than clobbered by the step that disables compression. Comparing against a fresh
+    # default context covers the whole set (OP_CIPHER_SERVER_PREFERENCE, OP_NO_SSLv3,
+    # OP_NO_TICKET, OP_ENABLE_MIDDLEBOX_COMPAT, ...) without pinning a per-version list.
+    default_options = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH).options
+    missing = default_options & ~context.options
+    assert not missing, f"dropped hardening options: {ssl.Options(missing)!r}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,12 +70,11 @@ def test_create_ssl_context() -> None:
     context = config.create_ssl_context()
 
     assert context is not None
-    # Compression is disabled (RFC 7540 9.2.1) ...
-    assert context.options & ssl.OP_NO_COMPRESSION
-    # ... and every hardening option create_default_context() sets is preserved rather
-    # than clobbered by the step that disables compression. Comparing against a fresh
-    # default context covers the whole set (OP_CIPHER_SERVER_PREFERENCE, OP_NO_SSLv3,
-    # OP_NO_TICKET, OP_ENABLE_MIDDLEBOX_COMPAT, ...) without pinning a per-version list.
+    # create_ssl_context disables compression (RFC 7540 9.2.1) on top of the hardened
+    # options create_default_context() sets. Every option the default enables - which
+    # includes compression already being disabled - must survive, rather than being
+    # cleared by the step that disables compression. Deriving the expectation from a
+    # fresh default context covers the whole set without pinning a per-version list.
     default_options = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH).options
     missing = default_options & ~context.options
     assert not missing, f"dropped hardening options: {ssl.Options(missing)!r}"


### PR DESCRIPTION
create_ssl_context assigned context.options = OP_NO_COMPRESSION, which replaces the entire options bitmask. create_default_context() returns a context with hardened flags already set (OP_CIPHER_SERVER_PREFERENCE, OP_SINGLE_DH_USE, OP_SINGLE_ECDH_USE, OP_NO_TICKET, ...), and the plain assignment cleared all of them, leaving only compression disabled - notably dropping server cipher-suite preference.

OR the flag in instead so the defaults are kept. The test previously asserted options was a subset of the NO_* protocol flags, which encoded the bug; it now checks that compression is disabled and the hardened defaults remain.


Claude-Session: https://claude.ai/code/session_011Fcnjz9Dicw52pye2Ga22o