### PR TITLE
Parse Forwarded headers with RFC 7239 optional whitespace

### DIFF
--- a/src/anycorn/middleware/proxy_fix.py
+++ b/src/anycorn/middleware/proxy_fix.py
@@ -37,27 +37,14 @@ class ProxyFixMiddleware:
             scheme: str | None = None
             host: str | None = None
 
-            if (
-                self.mode == "modern"
-                and (value := _get_trusted_value(b"forwarded", headers, self.trusted_hops))
-                is not None
-            ):
-                # RFC 7239 permits optional whitespace around the ";" separators,
-                # case-insensitive parameter names, and quoted values (e.g.
-                # for="[2001:db8::1]:4711"). Normalise each part before matching, so a
-                # header like "for=1.2.3.4; proto=https; host=example.com" is parsed
-                # rather than having proto and host silently dropped.
-                for part in value.split(";"):
-                    param, _, param_value = part.strip().partition("=")
-                    param_value = _unquote(param_value.strip())
-                    param = param.lower()
-                    if param == "for":
-                        client = param_value
-                    elif param == "host":
-                        host = param_value
-                    elif param == "proto":
-                        scheme = param_value
+            element = None
+            if self.mode == "modern":
+                element = _select_forwarded_element(headers, self.trusted_hops)
 
+            if element is not None:
+                client = element.get("for")
+                host = element.get("host")
+                scheme = element.get("proto")
             else:
                 client = _get_trusted_value(b"x-forwarded-for", headers, self.trusted_hops)
                 scheme = _get_trusted_value(b"x-forwarded-proto", headers, self.trusted_hops)
@@ -79,6 +66,75 @@ class ProxyFixMiddleware:
                 scope["headers"] = headers
 
         await self.app(scope, receive, send)
+
+
+def _split_outside_quotes(value: str, delimiter: str) -> list[str]:
+    r"""Split *value* on *delimiter*, ignoring delimiters inside a quoted-string.
+
+    RFC 7239 element (",") and pair (";") separators are structural only when they
+    sit outside a quoted-string, so a value such as ``host="a;b,c"`` is a single
+    pair carrying a single value rather than three fragments. Quote state is tracked
+    with RFC 7230 backslash escapes (an escaped quote does not end the string), and
+    the substrings are returned verbatim - quotes and escapes intact - for _unquote
+    to decode.
+    """
+    parts: list[str] = []
+    start = 0
+    in_quotes = False
+    escaped = False
+    for index, char in enumerate(value):
+        if escaped:
+            escaped = False
+        elif char == "\\" and in_quotes:
+            escaped = True
+        elif char == '"':
+            in_quotes = not in_quotes
+        elif char == delimiter and not in_quotes:
+            parts.append(value[start:index])
+            start = index + 1
+    parts.append(value[start:])
+    return parts
+
+
+def _parse_forwarded_element(element: str) -> dict[str, str]:
+    """Parse one Forwarded element into a mapping of lower-cased param to value.
+
+    A later duplicate of a param wins, matching how the last write of a repeated
+    field would be read; malformed pairs with no "=" are skipped.
+    """
+    pairs: dict[str, str] = {}
+    for pair in _split_outside_quotes(element, ";"):
+        name, sep, value = pair.partition("=")
+        if not sep:
+            continue
+        pairs[name.strip().lower()] = _unquote(value.strip())
+    return pairs
+
+
+def _select_forwarded_element(
+    headers: Iterable[tuple[bytes, bytes]], trusted_hops: int
+) -> dict[str, str] | None:
+    """Return the trusted Forwarded element (counting *trusted_hops* from the right).
+
+    All ``forwarded`` header fields are gathered and their comma-separated elements
+    concatenated, as a single field split across lines would be. Returns None when
+    there are fewer elements than trusted hops, so the caller falls back to the
+    X-Forwarded-* headers exactly as before.
+    """
+    if trusted_hops == 0:
+        return None
+
+    elements: list[dict[str, str]] = []
+    for name, value in headers:
+        if name.lower() == b"forwarded":
+            elements.extend(
+                _parse_forwarded_element(element)
+                for element in _split_outside_quotes(value.decode("latin1"), ",")
+            )
+
+    if len(elements) >= trusted_hops:
+        return elements[-trusted_hops]
+    return None
 
 
 def _unquote(value: str) -> str:

--- a/src/anycorn/middleware/proxy_fix.py
+++ b/src/anycorn/middleware/proxy_fix.py
@@ -42,13 +42,21 @@ class ProxyFixMiddleware:
                 and (value := _get_trusted_value(b"forwarded", headers, self.trusted_hops))
                 is not None
             ):
+                # RFC 7239 permits optional whitespace around the ";" separators,
+                # case-insensitive parameter names, and quoted values (e.g.
+                # for="[2001:db8::1]:4711"). Normalise each part before matching, so a
+                # header like "for=1.2.3.4; proto=https; host=example.com" is parsed
+                # rather than having proto and host silently dropped.
                 for part in value.split(";"):
-                    if part.startswith("for="):
-                        client = part[4:].strip()
-                    elif part.startswith("host="):
-                        host = part[5:].strip()
-                    elif part.startswith("proto="):
-                        scheme = part[6:].strip()
+                    param, _, param_value = part.strip().partition("=")
+                    param_value = param_value.strip().strip('"')
+                    param = param.lower()
+                    if param == "for":
+                        client = param_value
+                    elif param == "host":
+                        host = param_value
+                    elif param == "proto":
+                        scheme = param_value
 
             else:
                 client = _get_trusted_value(b"x-forwarded-for", headers, self.trusted_hops)

--- a/src/anycorn/middleware/proxy_fix.py
+++ b/src/anycorn/middleware/proxy_fix.py
@@ -49,7 +49,7 @@ class ProxyFixMiddleware:
                 # rather than having proto and host silently dropped.
                 for part in value.split(";"):
                     param, _, param_value = part.strip().partition("=")
-                    param_value = param_value.strip().strip('"')
+                    param_value = _unquote(param_value.strip())
                     param = param.lower()
                     if param == "for":
                         client = param_value
@@ -79,6 +79,36 @@ class ProxyFixMiddleware:
                 scope["headers"] = headers
 
         await self.app(scope, receive, send)
+
+
+def _unquote(value: str) -> str:
+    r"""Decode an RFC 7239 value: a bare token unchanged, a quoted-string unwrapped.
+
+    RFC 7239 says a value is a token or an RFC 7230 quoted-string, and inside a
+    quoted-string a backslash escapes the following character (so `\"` is a literal
+    quote and `\\` a literal backslash). Only unwrap when the value is actually
+    wrapped in a balanced pair of quotes; a bare token that happens to contain a
+    quote is left alone.
+    """
+    if len(value) < 2 or value[0] != '"' or value[-1] != '"':  # noqa: PLR2004
+        return value
+    inner = value[1:-1]
+    if "\\" not in inner:
+        return inner
+    unescaped: list[str] = []
+    escaped = False
+    for char in inner:
+        if escaped:
+            unescaped.append(char)
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        else:
+            unescaped.append(char)
+    if escaped:
+        # A lone trailing backslash (malformed) is kept as written.
+        unescaped.append("\\")
+    return "".join(unescaped)
 
 
 def _get_trusted_value(

--- a/tests/middleware/test_proxy_fix.py
+++ b/tests/middleware/test_proxy_fix.py
@@ -81,6 +81,43 @@ async def test_proxy_fix_modern() -> None:
 
 
 @pytest.mark.anyio
+async def test_proxy_fix_modern_with_optional_whitespace() -> None:
+    """RFC 7239 permits OWS after ";" and quoted values; both must still parse.
+
+    A header like "for=127.0.0.2; proto=https; host=example.com" previously left
+    proto and host unmatched (the parts began with a space), so scheme and host
+    were silently not rewritten.
+    """
+    mock = AsyncMock()
+    app = ProxyFixMiddleware(mock, mode="modern")
+    scope: HTTPScope = {
+        "type": "http",
+        "asgi": {},
+        "http_version": "2",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"forwarded", b'for="127.0.0.2"; proto=https; host=example.com'),
+        ],
+        "client": ("127.0.0.3", 80),
+        "server": None,
+        "extensions": {},
+        "state": ConnectionState({}),
+    }
+    await app(scope, None, None)  # type: ignore[invalid-argument-type]
+    mock.assert_called()
+    scope = mock.call_args[0][0]
+    assert scope["client"] == ("127.0.0.2", 0)
+    assert scope["scheme"] == "https"
+    host_headers = [h for h in scope["headers"] if h[0].lower() == b"host"]
+    assert host_headers == [(b"host", b"example.com")]
+
+
+@pytest.mark.anyio
 async def test_proxy_fix_keeps_unpicklable_state() -> None:
     """The scope carries whatever lifespan put in state, which need not be copyable.
 

--- a/tests/middleware/test_proxy_fix.py
+++ b/tests/middleware/test_proxy_fix.py
@@ -173,9 +173,7 @@ async def test_proxy_fix_modern_quoted_delimiters_are_not_split() -> None:
     """A "," or ";" inside a quoted value is data, not a separator."""
     mock = AsyncMock()
     app = ProxyFixMiddleware(mock, mode="modern")
-    scope = _http_scope(
-        [(b"forwarded", b'for="[2001:db8::1]:8080"; host="a;b,c"; proto=https')]
-    )
+    scope = _http_scope([(b"forwarded", b'for="[2001:db8::1]:8080"; host="a;b,c"; proto=https')])
     await app(scope, None, None)  # type: ignore[invalid-argument-type]
     scope = mock.call_args[0][0]
     assert scope["client"] == ("[2001:db8::1]:8080", 0)
@@ -193,9 +191,7 @@ async def test_proxy_fix_modern_quoted_comma_does_not_shift_hops() -> None:
     """
     mock = AsyncMock()
     app = ProxyFixMiddleware(mock, mode="modern", trusted_hops=2)
-    scope = _http_scope(
-        [(b"forwarded", b'for="a,b"; proto=http, for=2.2.2.2; proto=https')]
-    )
+    scope = _http_scope([(b"forwarded", b'for="a,b"; proto=http, for=2.2.2.2; proto=https')])
     await app(scope, None, None)  # type: ignore[invalid-argument-type]
     scope = mock.call_args[0][0]
     assert scope["client"] == ("a,b", 0)

--- a/tests/middleware/test_proxy_fix.py
+++ b/tests/middleware/test_proxy_fix.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from anycorn.middleware import ProxyFixMiddleware
-from anycorn.middleware.proxy_fix import _unquote
+from anycorn.middleware.proxy_fix import _split_outside_quotes, _unquote
 from anycorn.typing import ConnectionState, HTTPScope
 
 if TYPE_CHECKING:
@@ -98,6 +98,20 @@ def test_unquote(value: str, expected: str) -> None:
     assert _unquote(value) == expected
 
 
+@pytest.mark.parametrize(
+    ("value", "delimiter", "expected"),
+    [
+        ("a,b,c", ",", ["a", "b", "c"]),
+        ('for="a,b",for=c', ",", ['for="a,b"', "for=c"]),  # comma inside quotes
+        ('for=a;host="x;y";proto=z', ";", ["for=a", 'host="x;y"', "proto=z"]),
+        (r'for="a\"b,c"', ",", [r'for="a\"b,c"']),  # escaped quote keeps quotes open
+        ("", ",", [""]),
+    ],
+)
+def test_split_outside_quotes(value: str, delimiter: str, expected: list[str]) -> None:
+    assert _split_outside_quotes(value, delimiter) == expected
+
+
 @pytest.mark.anyio
 async def test_proxy_fix_modern_with_optional_whitespace() -> None:
     """RFC 7239 permits OWS after ";" and quoted values; both must still parse.
@@ -133,6 +147,59 @@ async def test_proxy_fix_modern_with_optional_whitespace() -> None:
     assert scope["scheme"] == "https"
     host_headers = [h for h in scope["headers"] if h[0].lower() == b"host"]
     assert host_headers == [(b"host", b"example.com")]
+
+
+def _http_scope(headers: list[tuple[bytes, bytes]]) -> HTTPScope:
+    return {
+        "type": "http",
+        "asgi": {},
+        "http_version": "2",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": headers,
+        "client": ("127.0.0.3", 80),
+        "server": None,
+        "extensions": {},
+        "state": ConnectionState({}),
+    }
+
+
+@pytest.mark.anyio
+async def test_proxy_fix_modern_quoted_delimiters_are_not_split() -> None:
+    """A "," or ";" inside a quoted value is data, not a separator."""
+    mock = AsyncMock()
+    app = ProxyFixMiddleware(mock, mode="modern")
+    scope = _http_scope(
+        [(b"forwarded", b'for="[2001:db8::1]:8080"; host="a;b,c"; proto=https')]
+    )
+    await app(scope, None, None)  # type: ignore[invalid-argument-type]
+    scope = mock.call_args[0][0]
+    assert scope["client"] == ("[2001:db8::1]:8080", 0)
+    assert scope["scheme"] == "https"
+    host_headers = [h for h in scope["headers"] if h[0].lower() == b"host"]
+    assert host_headers == [(b"host", b"a;b,c")]
+
+
+@pytest.mark.anyio
+async def test_proxy_fix_modern_quoted_comma_does_not_shift_hops() -> None:
+    """A comma inside a quoted value must not be counted as an extra element.
+
+    With trusted_hops=2 and two real elements, the trusted element is the first.
+    A naive comma split would see three fragments and pick the wrong one.
+    """
+    mock = AsyncMock()
+    app = ProxyFixMiddleware(mock, mode="modern", trusted_hops=2)
+    scope = _http_scope(
+        [(b"forwarded", b'for="a,b"; proto=http, for=2.2.2.2; proto=https')]
+    )
+    await app(scope, None, None)  # type: ignore[invalid-argument-type]
+    scope = mock.call_args[0][0]
+    assert scope["client"] == ("a,b", 0)
+    assert scope["scheme"] == "http"
 
 
 @pytest.mark.anyio

--- a/tests/middleware/test_proxy_fix.py
+++ b/tests/middleware/test_proxy_fix.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from anycorn.middleware import ProxyFixMiddleware
+from anycorn.middleware.proxy_fix import _unquote
 from anycorn.typing import ConnectionState, HTTPScope
 
 if TYPE_CHECKING:
@@ -78,6 +79,23 @@ async def test_proxy_fix_modern() -> None:
     assert scope["scheme"] == "https"
     host_headers = [h for h in scope["headers"] if h[0].lower() == b"host"]
     assert host_headers == [(b"host", b"example.com")]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("192.0.2.60", "192.0.2.60"),  # bare token, unchanged
+        ('"192.0.2.60"', "192.0.2.60"),  # quoted-string, unwrapped
+        ('"[2001:db8::1]:4711"', "[2001:db8::1]:4711"),  # quoted IPv6
+        (r'"a\"b"', 'a"b'),  # quoted-pair: escaped quote
+        (r'"a\\b"', r"a\b"),  # quoted-pair: escaped backslash
+        ('""', ""),  # empty quoted-string
+        ('"', '"'),  # single quote is not a balanced pair
+        ('a"b', 'a"b'),  # stray quote in a token is left alone
+    ],
+)
+def test_unquote(value: str, expected: str) -> None:
+    assert _unquote(value) == expected
 
 
 @pytest.mark.anyio

--- a/tests/middleware/test_proxy_fix.py
+++ b/tests/middleware/test_proxy_fix.py
@@ -9,7 +9,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from anycorn.middleware import ProxyFixMiddleware
-from anycorn.middleware.proxy_fix import _split_outside_quotes, _unquote
+from anycorn.middleware.proxy_fix import (
+    _parse_forwarded_element,
+    _split_outside_quotes,
+    _unquote,
+)
 from anycorn.typing import ConnectionState, HTTPScope
 
 if TYPE_CHECKING:
@@ -110,6 +114,27 @@ def test_unquote(value: str, expected: str) -> None:
 )
 def test_split_outside_quotes(value: str, delimiter: str, expected: list[str]) -> None:
     assert _split_outside_quotes(value, delimiter) == expected
+
+
+@pytest.mark.parametrize(
+    ("element", "expected"),
+    [
+        # Behaviours cross-checked against aiohttp's RFC 7239 parser.
+        (
+            "for=192.0.2.60;proto=http;by=203.0.113.43",
+            {"for": "192.0.2.60", "proto": "http", "by": "203.0.113.43"},
+        ),
+        ("for=1.1.1.1;for=2.2.2.2", {"for": "2.2.2.2"}),  # duplicate param: last wins
+        ("proto=https;;for=1.1.1.1", {"proto": "https", "for": "1.1.1.1"}),  # empty pair skipped
+        # Full port kept - aiohttp truncates this to :4701 (its regex caps at 4 digits).
+        ("for=192.0.2.43:47011", {"for": "192.0.2.43:47011"}),
+        ('secret=";,="', {"secret": ";,="}),  # delimiters inside quotes are data
+        ("novalue", {}),  # a pair with no "=" is skipped
+        ("", {}),  # empty element
+    ],
+)
+def test_parse_forwarded_element(element: str, expected: dict[str, str]) -> None:
+    assert _parse_forwarded_element(element) == expected
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
ProxyFixMiddleware's "modern" mode matched `Forwarded` parameters with str.startswith on `value.split(";")` without stripping. RFC 7239 permits optional whitespace around the ";" separators, so a valid header such as `for=1.2.3.4; proto=https; host=example.com` left proto and host unmatched and the scheme/host rewrites were silently skipped.

Normalise each part before matching: strip surrounding whitespace, split on the first "=", strip and unquote the value, and lower-case the parameter name (RFC 7239 names are case-insensitive). This also handles quoted values like `for="[2001:db8::1]:4711"`.


Claude-Session: https://claude.ai/code/session_011Fcnjz9Dicw52pye2Ga22o