### PR TITLE
Hand a queued disconnect to the app without a leading checkpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
     "httpx2",
     "pytest>=9.1.1",
     "mock",
+    "starlette",
     "trio",
     "trustme",
 ]

--- a/src/anycorn/task_group.py
+++ b/src/anycorn/task_group.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import anyio
 import anyio.abc
@@ -27,6 +27,31 @@ else:
     from typing_extensions import Self
 
 
+def _receive_without_leading_checkpoint(
+    channel: anyio.streams.memory.MemoryObjectReceiveStream[ASGIReceiveEvent],
+) -> ASGIReceiveCallable:
+    """Return a receive() that hands over an already-queued event without checkpointing.
+
+    anyio's ``MemoryObjectReceiveStream.receive`` checkpoints before returning even a
+    buffered event. Starlette's ``Request.is_disconnected`` polls receive() inside an
+    already-cancelled scope to pick up a queued ``http.disconnect`` without waiting;
+    the leading checkpoint is cancelled before the disconnect is returned, so the app
+    never learns the client has gone. Return a buffered event synchronously, and only
+    checkpoint - as a normal receive would - when there is nothing to hand over.
+    """
+
+    async def receive() -> ASGIReceiveEvent:
+        try:
+            return channel.receive_nowait()
+        except anyio.WouldBlock:
+            # channel.receive() checkpoints itself before waiting, so nothing extra is
+            # needed here - the point is only to skip that checkpoint when an event is
+            # already queued, which the receive_nowait above does.
+            return await channel.receive()
+
+    return receive
+
+
 async def _handle(  # noqa: PLR0913
     app: AppWrapper,
     config: Config,
@@ -42,7 +67,7 @@ async def _handle(  # noqa: PLR0913
     app_send_channel, app_receive_channel = channels
     try:
         async with app_send_channel, app_receive_channel:
-            receive = cast("ASGIReceiveCallable", app_receive_channel.receive)
+            receive = _receive_without_leading_checkpoint(app_receive_channel)
             await app(scope, receive, send, sync_spawn, call_soon)
     except anyio.get_cancelled_exc_class():
         raise

--- a/tests/e2e/test_starlette_disconnect_socket.py
+++ b/tests/e2e/test_starlette_disconnect_socket.py
@@ -10,7 +10,7 @@ queued http.disconnect is never handed over and the handler never notices.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import anyio
 import pytest
@@ -23,6 +23,8 @@ from anycorn.config import Config
 
 if TYPE_CHECKING:
     from starlette.requests import Request
+
+    from anycorn.typing import ASGIFramework
 
 # The handler gives up polling after this long so a regression fails the test
 # (via the detected-event timeout below) rather than hanging it.
@@ -55,7 +57,10 @@ async def test_starlette_sees_a_real_socket_disconnect(free_tcp_port: int) -> No
         shutdown = anyio.Event()
         await tg.start(
             lambda *, task_status: anycorn.serve(
-                app, config, shutdown_trigger=shutdown.wait, task_status=task_status
+                cast("ASGIFramework", app),
+                config,
+                shutdown_trigger=shutdown.wait,
+                task_status=task_status,
             )
         )
 

--- a/tests/e2e/test_starlette_disconnect_socket.py
+++ b/tests/e2e/test_starlette_disconnect_socket.py
@@ -1,0 +1,76 @@
+"""A real Starlette app, over a real socket, must see the client hang up.
+
+Companion to tests/test_starlette_disconnect.py, which drives spawn_app in
+memory. This one runs a real anycorn server on a real TCP port with a real
+Starlette app, and hangs up a real client socket while a handler is polling
+Request.is_disconnected() - the exact shape of a long-running handler noticing
+its client has gone. Without the leading-checkpoint fix in task_group the
+queued http.disconnect is never handed over and the handler never notices.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import anyio
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+import anycorn
+from anycorn.config import Config
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+# The handler gives up polling after this long so a regression fails the test
+# (via the detected-event timeout below) rather than hanging it.
+_DETECT_TIMEOUT = 5.0
+
+
+@pytest.mark.anyio
+async def test_starlette_sees_a_real_socket_disconnect(free_tcp_port: int) -> None:
+    """A polling handler must detect a disconnect delivered over a real socket."""
+    started = anyio.Event()
+    detected = anyio.Event()
+
+    async def endpoint(request: Request) -> PlainTextResponse:
+        started.set()
+        with anyio.move_on_after(_DETECT_TIMEOUT):
+            # Polling is_disconnected() is the mechanism under test - exactly what a
+            # long-running Starlette handler does - so an Event wait can't replace it.
+            while not await request.is_disconnected():  # noqa: ASYNC110
+                await anyio.sleep(0.01)
+            detected.set()
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/", endpoint)])
+
+    config = Config()
+    config.bind = [f"127.0.0.1:{free_tcp_port}"]
+    config.errorlog = "-"
+
+    async with anyio.create_task_group() as tg:
+        shutdown = anyio.Event()
+        await tg.start(
+            lambda *, task_status: anycorn.serve(
+                app, config, shutdown_trigger=shutdown.wait, task_status=task_status
+            )
+        )
+
+        stream = await anyio.connect_tcp("127.0.0.1", free_tcp_port)
+        try:
+            await stream.send(b"GET / HTTP/1.1\r\nhost: anycorn\r\n\r\n")
+            # Wait until the handler is actually running and polling before hanging
+            # up, so this is a mid-request disconnect, not a race with startup.
+            with anyio.fail_after(10):
+                await started.wait()
+        finally:
+            await stream.aclose()  # the client goes away
+
+        with anyio.fail_after(10):
+            await detected.wait()
+        shutdown.set()
+
+    assert detected.is_set()

--- a/tests/test_starlette_disconnect.py
+++ b/tests/test_starlette_disconnect.py
@@ -1,0 +1,83 @@
+"""A real Starlette app must see a client disconnect through anycorn's receive.
+
+Starlette's Request.is_disconnected() polls receive() inside an already-cancelled
+scope, so a receive() that checkpoints before returning a buffered http.disconnect
+never hands it over and the app never learns the client has gone.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import anyio
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+from anycorn.app_wrappers import ASGIWrapper
+from anycorn.config import Config
+from anycorn.task_group import TaskGroup
+from anycorn.typing import ConnectionState
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+    from anycorn.typing import ASGIFramework, HTTPScope
+
+_MAX_POLLS = 50
+
+
+def _http_scope() -> HTTPScope:
+    return {
+        "type": "http",
+        "http_version": "1.1",
+        "asgi": {"spec_version": "2.1", "version": "3.0"},
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"host", b"anycorn")],
+        "client": ("127.0.0.1", 1234),
+        "server": ("127.0.0.1", 8000),
+        "extensions": {},
+        "state": ConnectionState({}),
+    }
+
+
+@pytest.mark.anyio
+async def test_starlette_app_detects_a_client_disconnect() -> None:
+    """A real Starlette handler polling is_disconnected() must see a queued disconnect."""
+    detected: dict[str, bool] = {}
+
+    async def endpoint(request: Request) -> PlainTextResponse:
+        # As a long-running handler does: check periodically whether the client is
+        # still there. Without the fix this stays False forever and loops out.
+        for _ in range(_MAX_POLLS):
+            if await request.is_disconnected():
+                detected["disconnected"] = True
+                break
+            await anyio.sleep(0.001)
+        else:
+            detected["disconnected"] = False
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/", endpoint)])
+
+    responses: list[Any] = []
+
+    async def send(message: Any) -> None:  # noqa: ANN401
+        if message is not None:
+            responses.append(message)
+
+    with anyio.fail_after(5):
+        async with TaskGroup() as task_group:
+            put = await task_group.spawn_app(
+                ASGIWrapper(cast("ASGIFramework", app)), Config(), _http_scope(), send
+            )
+            # The client goes away: a disconnect is queued for the running handler.
+            await put({"type": "http.disconnect"})
+
+    assert detected["disconnected"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,7 @@ dev = [
     { name = "mock" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "starlette" },
     { name = "trio" },
     { name = "trustme" },
     { name = "ty" },
@@ -69,6 +70,7 @@ test = [
     { name = "httpx2" },
     { name = "mock" },
     { name = "pytest" },
+    { name = "starlette" },
     { name = "trio" },
     { name = "trustme" },
 ]
@@ -97,6 +99,7 @@ dev = [
     { name = "mock" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.6" },
+    { name = "starlette" },
     { name = "trio" },
     { name = "trustme" },
     { name = "ty", specifier = ">=0.0.22" },
@@ -106,6 +109,7 @@ test = [
     { name = "httpx2" },
     { name = "mock" },
     { name = "pytest", specifier = ">=9.1.1" },
+    { name = "starlette" },
     { name = "trio" },
     { name = "trustme" },
 ]
@@ -315,7 +319,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -651,6 +655,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/davidbrochart/anycorn/pull/8

anyio's MemoryObjectReceiveStream.receive checkpoints before returning even a buffered event. Starlette's Request.is_disconnected() polls receive() inside an already-cancelled scope to pick up a queued http.disconnect without waiting, so the leading checkpoint is cancelled before the disconnect is returned and a Starlette app never learns the client has gone.

Wrap the app's receive so an already-queued event is returned synchronously via receive_nowait(), checkpointing only when there is nothing to hand over. This ports the workaround from the old starlette-disconnect branch (originally by David Brochart and John Litborn) onto the current task group.

Add a test that drives a real Starlette app through the task group - a handler polling is_disconnected() must see a queued disconnect; it fails against the raw checkpointing receive. starlette is added to the test dependencies.



Claude-Session: https://claude.ai/code/session_011Fcnjz9Dicw52pye2Ga22o