### PR TITLE
Adopt listening sockets via the public SocketListener.from_socket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "h11",
     "h2 >=3.1.0",
     "hpack",
-    "anyio >=4.0,<5.0",
+    "anyio >=4.10.0,<5.0",
     "priority",
     "sniffio >=1.1,<2.0",
     "tomli; python_version<'3.11'",

--- a/src/anycorn/run.py
+++ b/src/anycorn/run.py
@@ -258,9 +258,8 @@ async def worker_serve(  # noqa: C901, PLR0912, PLR0915
             binds = []
             for secure_sock in sockets.secure_sockets:
                 assert ssl_context is not None
-                asynclib = anyio._core._eventloop.get_async_backend()  # noqa: SLF001  # ty:ignore[possibly-missing-attribute]
                 secure_listener = anyio.streams.tls.TLSListener(
-                    asynclib.create_tcp_listener(secure_sock),
+                    await anyio.abc.SocketListener.from_socket(secure_sock),
                     ssl_context,
                     True,  # noqa: FBT003
                     config.ssl_handshake_timeout,
@@ -272,8 +271,7 @@ async def worker_serve(  # noqa: C901, PLR0912, PLR0915
                 await config.log.info("Running on %s (CTRL + C to quit)", url)
 
             for insecure_sock in sockets.insecure_sockets:
-                asynclib = anyio._core._eventloop.get_async_backend()  # noqa: SLF001  # ty:ignore[possibly-missing-attribute]
-                insecure_listener = asynclib.create_tcp_listener(insecure_sock)
+                insecure_listener = await anyio.abc.SocketListener.from_socket(insecure_sock)
                 listeners.append(await socket_stack.enter_async_context(insecure_listener))
                 bind = repr_socket_addr(insecure_sock.family, insecure_sock.getsockname())
                 url = f"http://{bind}"

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aioquic", marker = "extra == 'h3'", specifier = ">=1.2.0,<2.0.0" },
-    { name = "anyio", specifier = ">=4.0,<5.0" },
+    { name = "anyio", specifier = ">=4.10.0,<5.0" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.1.0,<2.0" },
     { name = "h11" },
     { name = "h2", specifier = ">=3.1.0" },
@@ -315,7 +315,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [


### PR DESCRIPTION
Wrapping anycorn's already-created, listening sockets in anyio listeners was done by reaching into anyio._core._eventloop.get_async_backend() and calling its create_tcp_listener(sock) - private internals, carrying an SLF001 noqa and a ty possibly-missing-attribute ignore. anyio 4.10 added a public API for exactly this, SocketListener.from_socket(sock), so use it for both the TLS and plain listeners and drop the private access and its suppressions. Requires bumping the anyio floor to >=4.10.0.


Claude-Session: https://claude.ai/code/session_011Fcnjz9Dicw52pye2Ga22o