### PR TITLE
Implement ASGI send-on-disconnect and advertise spec version 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Unreleased
+
+- Advertise ASGI spec version 2.5. Raise a `ClientDisconnected` (an `OSError` subclass)
+  from the app's `send` once the client has disconnected, as spec 2.4 requires, and
+  carry the peer's close reason on the WebSocket `websocket.disconnect` event.
+
 ## 0.20.0
 
 - Hold websocket data that arrives before the app accepts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   carry the peer's close reason on the WebSocket `websocket.disconnect` event.
 - Implement the Path Send extension (`http.response.pathsend`), streaming a file the
   app names by path as the response body on any HTTP version.
+- Add a `Config.asgi_spec_version` option (default `"2.5"`) to pin the advertised
+  spec version. The behaviour follows it: below `"2.4"` a `send` after disconnect is
+  dropped rather than raising, and below `"2.5"` the `websocket.disconnect` carries no
+  reason - so an app that depends on the older behaviour can opt out.
 
 ## 0.20.0
 

--- a/src/anycorn/__init__.py
+++ b/src/anycorn/__init__.py
@@ -8,14 +8,14 @@ import anyio.abc
 
 from .config import Config
 from .run import worker_serve
-from .utils import wrap_app
+from .utils import ClientDisconnected, wrap_app
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from .typing import Framework
 
-__all__ = ("Config", "serve")
+__all__ = ("ClientDisconnected", "Config", "serve")
 __version__ = importlib.metadata.version("anycorn")
 
 

--- a/src/anycorn/config.py
+++ b/src/anycorn/config.py
@@ -112,6 +112,10 @@ class Config:
     alpn_protocols: list[str]
     alt_svc_headers: ClassVar[list[str]] = []
     application_path: str
+    # The ASGI HTTP/WebSocket (www) spec version advertised to apps in the scope.
+    # Behaviour follows it: >= "2.4" makes send() raise once the client has gone,
+    # and >= "2.5" carries the peer's reason on a websocket.disconnect.
+    asgi_spec_version: str = "2.5"
     backlog = 100
     ca_certs: str | None = None
     certfile: str | None = None

--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -27,6 +27,7 @@ from anycorn.utils import (
     UnexpectedMessageError,
     build_and_validate_headers,
     decode_asgi_path,
+    parse_spec_version,
     suppress_body,
     valid_request_target,
     valid_server_name,
@@ -102,6 +103,7 @@ class HTTPStream:
         self.task_group = task_group
         self.tls = tls
         self.scheme = "https" if self.tls is not None else "http"
+        self._spec_version = parse_spec_version(config.asgi_spec_version)
 
     @property
     def idle(self) -> bool:
@@ -143,7 +145,7 @@ class HTTPStream:
             self.scope = HTTPScope(
                 type="http",
                 http_version=event.http_version,
-                asgi={"spec_version": "2.5", "version": "3.0"},
+                asgi={"spec_version": self.config.asgi_spec_version, "version": "3.0"},
                 method=event.method,
                 scheme=self.scheme,
                 path=decoded_path,
@@ -202,9 +204,10 @@ class HTTPStream:
                     await self.send(StreamClosed(stream_id=self.stream_id))
             return
 
-        if self.closed:
-            # ASGI spec 2.4: the client has disconnected, so a send() must raise. The
+        if self.closed and self._spec_version >= (2, 4):
+            # From spec 2.4 the client has disconnected, so a send() must raise. The
             # None sentinel above is the app finishing, not a send, so it returns first.
+            # Below 2.4 the send is left to fall through and be dropped, as it used to.
             raise ClientDisconnected
 
         if message["type"] == "http.response.start" and self.state == ASGIHTTPState.REQUEST:

--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -20,6 +20,7 @@ from anycorn.typing import (
     WorkerContext,
 )
 from anycorn.utils import (
+    ClientDisconnected,
     InvalidRequestPathError,
     UnexpectedMessageError,
     build_and_validate_headers,
@@ -135,7 +136,7 @@ class HTTPStream:
             self.scope = HTTPScope(
                 type="http",
                 http_version=event.http_version,
-                asgi={"spec_version": "2.1", "version": "3.0"},
+                asgi={"spec_version": "2.5", "version": "3.0"},
                 method=event.method,
                 scheme=self.scheme,
                 path=decoded_path,
@@ -182,7 +183,7 @@ class HTTPStream:
             if self.app_put is not None:
                 await self.app_put({"type": "http.disconnect"})
 
-    async def app_send(self, message: ASGISendEvent | None) -> None:  # noqa: C901, PLR0912
+    async def app_send(self, message: ASGISendEvent | None) -> None:  # noqa: C901, PLR0912, PLR0915
         """Handle a message sent by the ASGI application."""
         if message is None:  # ASGI App has finished sending messages
             if not self.closed:
@@ -192,7 +193,14 @@ class HTTPStream:
                     await self._send_error_response(500)
                 else:
                     await self.send(StreamClosed(stream_id=self.stream_id))
-        elif message["type"] == "http.response.start" and self.state == ASGIHTTPState.REQUEST:
+            return
+
+        if self.closed:
+            # ASGI spec 2.4: the client has disconnected, so a send() must raise. The
+            # None sentinel above is the app finishing, not a send, so it returns first.
+            raise ClientDisconnected
+
+        if message["type"] == "http.response.start" and self.state == ASGIHTTPState.REQUEST:
             self.response = message
             headers = build_and_validate_headers(self.response.get("headers", []))
             await self.send(

--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -22,6 +22,7 @@ from anycorn.typing import (
     WorkerContext,
 )
 from anycorn.utils import (
+    ClientDisconnected,
     InvalidRequestPathError,
     UnexpectedMessageError,
     build_and_validate_headers,
@@ -159,7 +160,7 @@ class HTTPStream:
             self.scope = HTTPScope(
                 type="http",
                 http_version=event.http_version,
-                asgi={"spec_version": "2.1", "version": "3.0"},
+                asgi={"spec_version": "2.5", "version": "3.0"},
                 method=event.method,
                 scheme=self.scheme,
                 path=decoded_path,
@@ -216,7 +217,14 @@ class HTTPStream:
                     await self._send_error_response(500)
                 else:
                     await self.send(StreamClosed(stream_id=self.stream_id))
-        elif message["type"] == "http.response.start" and self.state == ASGIHTTPState.REQUEST:
+            return
+
+        if self.closed:
+            # ASGI spec 2.4: the client has disconnected, so a send() must raise. The
+            # None sentinel above is the app finishing, not a send, so it returns first.
+            raise ClientDisconnected
+
+        if message["type"] == "http.response.start" and self.state == ASGIHTTPState.REQUEST:
             self.response = message
             headers = build_and_validate_headers(self.response.get("headers", []))
             await self.send(

--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -27,6 +27,7 @@ from anycorn.utils import (
     UnexpectedMessageError,
     build_and_validate_headers,
     decode_asgi_path,
+    parse_spec_version,
     suppress_body,
     valid_request_target,
     valid_server_name,
@@ -111,6 +112,7 @@ class HTTPStream:
         # the zerocopysend extension is not advertised.
         self.zero_copy_send = zero_copy_send
         self.scheme = "https" if self.tls is not None else "http"
+        self._spec_version = parse_spec_version(config.asgi_spec_version)
 
     @property
     def idle(self) -> bool:
@@ -160,7 +162,7 @@ class HTTPStream:
             self.scope = HTTPScope(
                 type="http",
                 http_version=event.http_version,
-                asgi={"spec_version": "2.5", "version": "3.0"},
+                asgi={"spec_version": self.config.asgi_spec_version, "version": "3.0"},
                 method=event.method,
                 scheme=self.scheme,
                 path=decoded_path,
@@ -219,9 +221,10 @@ class HTTPStream:
                     await self.send(StreamClosed(stream_id=self.stream_id))
             return
 
-        if self.closed:
-            # ASGI spec 2.4: the client has disconnected, so a send() must raise. The
+        if self.closed and self._spec_version >= (2, 4):
+            # From spec 2.4 the client has disconnected, so a send() must raise. The
             # None sentinel above is the app finishing, not a send, so it returns first.
+            # Below 2.4 the send is left to fall through and be dropped, as it used to.
             raise ClientDisconnected
 
         if message["type"] == "http.response.start" and self.state == ASGIHTTPState.REQUEST:

--- a/src/anycorn/protocol/ws_stream.py
+++ b/src/anycorn/protocol/ws_stream.py
@@ -30,6 +30,7 @@ from anycorn.typing import (
     TaskGroup,
     TLSExtension,
     WebsocketAcceptEvent,
+    WebsocketDisconnectEvent,
     WebsocketResponseBodyEvent,
     WebsocketResponseStartEvent,
     WebsocketScope,
@@ -44,6 +45,7 @@ from anycorn.utils import (
     UnexpectedMessageError,
     build_and_validate_headers,
     decode_asgi_path,
+    parse_spec_version,
     suppress_body,
     valid_request_target,
     valid_server_name,
@@ -243,6 +245,7 @@ class WSStream:
         self.stream_id = stream_id
         self.tls = tls
         self.scheme = "wss" if self.tls is not None else "ws"
+        self._spec_version = parse_spec_version(config.asgi_spec_version)
 
         self.connection: Connection
         self.handshake: Handshake
@@ -276,7 +279,7 @@ class WSStream:
             extensions["websocket.http.response"] = {}
             self.scope = {
                 "type": "websocket",
-                "asgi": {"spec_version": "2.5", "version": "3.0"},
+                "asgi": {"spec_version": self.config.asgi_spec_version, "version": "3.0"},
                 "scheme": self.scheme,
                 "http_version": event.http_version,
                 "path": decoded_path,
@@ -335,9 +338,14 @@ class WSStream:
                     code = CloseReason.NORMAL_CLOSURE.value
                 else:
                     code = CloseReason.ABNORMAL_CLOSURE.value
-                await self.app_put(
-                    {"type": "websocket.disconnect", "code": code, "reason": self.close_reason}
-                )
+                disconnect: WebsocketDisconnectEvent = {
+                    "type": "websocket.disconnect",
+                    "code": code,
+                }
+                if self._spec_version >= (2, 5):
+                    # The reason on the disconnect event is a spec 2.5 addition.
+                    disconnect["reason"] = self.close_reason
+                await self.app_put(disconnect)
 
     async def app_send(self, message: ASGISendEvent | None) -> None:  # noqa: C901, PLR0912
         """Handle a message sent by the ASGI application."""
@@ -359,9 +367,10 @@ class WSStream:
                     await self.send(StreamClosed(stream_id=self.stream_id))
             return
 
-        if self.closed:
-            # ASGI spec 2.4: the client has disconnected, so a send() must raise. The
+        if self.closed and self._spec_version >= (2, 4):
+            # From spec 2.4 the client has disconnected, so a send() must raise. The
             # None sentinel above is the app finishing, not a send, so it returns first.
+            # Below 2.4 the send is left to fall through and be dropped, as it used to.
             raise ClientDisconnected
 
         if message["type"] == "websocket.accept" and self.state == ASGIWebsocketState.HANDSHAKE:

--- a/src/anycorn/protocol/ws_stream.py
+++ b/src/anycorn/protocol/ws_stream.py
@@ -39,6 +39,7 @@ from anycorn.typing import (
     ConnectionState as ASGIConnectionState,  # wsproto has one of its own
 )
 from anycorn.utils import (
+    ClientDisconnected,
     InvalidRequestPathError,
     UnexpectedMessageError,
     build_and_validate_headers,
@@ -224,6 +225,8 @@ class WSStream:
         # The code the peer closed with, once it has sent a close frame, so the ASGI
         # disconnect reports it rather than defaulting to 1006 (abnormal closure).
         self.close_code: int | None = None
+        # The reason the peer closed with, surfaced on the ASGI disconnect (spec 2.5).
+        self.close_reason: str | None = None
         self.config = config
         self.context = context
         self.task_group = task_group
@@ -273,7 +276,7 @@ class WSStream:
             extensions["websocket.http.response"] = {}
             self.scope = {
                 "type": "websocket",
-                "asgi": {"spec_version": "2.3", "version": "3.0"},
+                "asgi": {"spec_version": "2.5", "version": "3.0"},
                 "scheme": self.scheme,
                 "http_version": event.http_version,
                 "path": decoded_path,
@@ -332,28 +335,36 @@ class WSStream:
                     code = CloseReason.NORMAL_CLOSURE.value
                 else:
                     code = CloseReason.ABNORMAL_CLOSURE.value
-                await self.app_put({"type": "websocket.disconnect", "code": code})
+                await self.app_put(
+                    {"type": "websocket.disconnect", "code": code, "reason": self.close_reason}
+                )
 
     async def app_send(self, message: ASGISendEvent | None) -> None:  # noqa: C901, PLR0912
         """Handle a message sent by the ASGI application."""
-        if self.closed:
-            # Allow app to finish after close
+        if message is None:  # ASGI App has finished sending messages
+            # Allow the app to finish after close; only clean up if still open.
+            if not self.closed:
+                if self.state == ASGIWebsocketState.HANDSHAKE:
+                    # _send_error_response logs the request and closes the stream
+                    # itself, as it does for the 400s and 404s in handle(); logging
+                    # again here put the same line in the access log twice, so anything
+                    # counting requests double-counted an app that failed during the
+                    # handshake. HTTPStream does not do this.
+                    await self._send_error_response(500)
+                else:
+                    if self.state == ASGIWebsocketState.CONNECTED:
+                        await self._send_wsproto_event(
+                            CloseConnection(code=CloseReason.INTERNAL_ERROR)
+                        )
+                    await self.send(StreamClosed(stream_id=self.stream_id))
             return
 
-        if message is None:  # ASGI App has finished sending messages
-            # Cleanup if required
-            if self.state == ASGIWebsocketState.HANDSHAKE:
-                # _send_error_response logs the request and closes the stream
-                # itself, as it does for the 400s and 404s in handle(); logging
-                # again here put the same line in the access log twice, so anything
-                # counting requests double-counted an app that failed during the
-                # handshake. HTTPStream does not do this.
-                await self._send_error_response(500)
-            else:
-                if self.state == ASGIWebsocketState.CONNECTED:
-                    await self._send_wsproto_event(CloseConnection(code=CloseReason.INTERNAL_ERROR))
-                await self.send(StreamClosed(stream_id=self.stream_id))
-        elif message["type"] == "websocket.accept" and self.state == ASGIWebsocketState.HANDSHAKE:
+        if self.closed:
+            # ASGI spec 2.4: the client has disconnected, so a send() must raise. The
+            # None sentinel above is the app finishing, not a send, so it returns first.
+            raise ClientDisconnected
+
+        if message["type"] == "websocket.accept" and self.state == ASGIWebsocketState.HANDSHAKE:
             await self._accept(message)
         elif (
             message["type"] == "websocket.http.response.start"
@@ -421,6 +432,7 @@ class WSStream:
                 # carries that code rather than 1006.
                 # https://github.com/pgjones/hypercorn/issues/127
                 self.close_code = event.code
+                self.close_reason = event.reason
                 if self.connection.state == ConnectionState.REMOTE_CLOSING:
                     await self._send_wsproto_event(event.response())
                 await self.send(StreamClosed(stream_id=self.stream_id))

--- a/src/anycorn/task_group.py
+++ b/src/anycorn/task_group.py
@@ -13,6 +13,7 @@ import anyio.streams.memory
 import anyio.to_thread
 
 from .typing import AppWrapper, ASGIReceiveCallable, ASGIReceiveEvent, ASGISendEvent, Scope
+from .utils import ClientDisconnected
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -46,6 +47,10 @@ async def _handle(  # noqa: PLR0913
             await app(scope, receive, send, sync_spawn, call_soon)
     except anyio.get_cancelled_exc_class():
         raise
+    except ClientDisconnected:
+        # The client went away and the app let the send() error propagate rather than
+        # handling it (spec 2.4 permits this). That is a normal end, not a failure.
+        pass
     except BaseExceptionGroup as error:
         _, other_errors = error.split(anyio.get_cancelled_exc_class())
         if other_errors is not None:

--- a/src/anycorn/task_group.py
+++ b/src/anycorn/task_group.py
@@ -13,6 +13,7 @@ import anyio.streams.memory
 import anyio.to_thread
 
 from .typing import AppWrapper, ASGIReceiveCallable, ASGIReceiveEvent, ASGISendEvent, Scope
+from .utils import ClientDisconnected
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -71,6 +72,10 @@ async def _handle(  # noqa: PLR0913
             await app(scope, receive, send, sync_spawn, call_soon)
     except anyio.get_cancelled_exc_class():
         raise
+    except ClientDisconnected:
+        # The client went away and the app let the send() error propagate rather than
+        # handling it (spec 2.4 permits this). That is a normal end, not a failure.
+        pass
     except BaseExceptionGroup as error:
         _, other_errors = error.split(anyio.get_cancelled_exc_class())
         if other_errors is not None:

--- a/src/anycorn/typing.py
+++ b/src/anycorn/typing.py
@@ -232,7 +232,8 @@ class WebsocketDisconnectEvent(TypedDict):
 
     type: Literal["websocket.disconnect"]
     code: int
-    reason: str | None
+    # Carried only when the advertised spec_version is >= 2.5.
+    reason: NotRequired[str | None]
 
 
 class WebsocketCloseEvent(TypedDict):

--- a/src/anycorn/typing.py
+++ b/src/anycorn/typing.py
@@ -224,6 +224,7 @@ class WebsocketDisconnectEvent(TypedDict):
 
     type: Literal["websocket.disconnect"]
     code: int
+    reason: str | None
 
 
 class WebsocketCloseEvent(TypedDict):

--- a/src/anycorn/typing.py
+++ b/src/anycorn/typing.py
@@ -243,7 +243,8 @@ class WebsocketDisconnectEvent(TypedDict):
 
     type: Literal["websocket.disconnect"]
     code: int
-    reason: str | None
+    # Carried only when the advertised spec_version is >= 2.5.
+    reason: NotRequired[str | None]
 
 
 class WebsocketCloseEvent(TypedDict):

--- a/src/anycorn/typing.py
+++ b/src/anycorn/typing.py
@@ -243,6 +243,7 @@ class WebsocketDisconnectEvent(TypedDict):
 
     type: Literal["websocket.disconnect"]
     code: int
+    reason: str | None
 
 
 class WebsocketCloseEvent(TypedDict):

--- a/src/anycorn/utils.py
+++ b/src/anycorn/utils.py
@@ -82,6 +82,24 @@ class UnexpectedMessageError(Exception):
         super().__init__(f"Unexpected message type, {message_type} given the state {state}")
 
 
+SPEC_VERSIONS = ("2.0", "2.1", "2.2", "2.3", "2.4", "2.5")
+
+
+def parse_spec_version(value: str) -> tuple[int, int]:
+    """Validate an ASGI www spec version string, returning it as a (major, minor) tuple.
+
+    Raises ValueError for anything anycorn does not implement, so a misconfigured
+    ``Config.asgi_spec_version`` fails loudly rather than advertising a version whose
+    behaviour the server does not provide.
+    """
+    if value not in SPEC_VERSIONS:
+        allowed = ", ".join(SPEC_VERSIONS)
+        msg = f"Unknown ASGI spec_version {value!r}; expected one of {allowed}"
+        raise ValueError(msg)
+    major, minor = value.split(".")
+    return int(major), int(minor)
+
+
 class FrameTooLargeError(Exception):
     """Raised when a WebSocket frame exceeds the maximum allowed size."""
 

--- a/src/anycorn/utils.py
+++ b/src/anycorn/utils.py
@@ -66,6 +66,15 @@ class InvalidRequestPathError(ValueError):
     """Raised when a request path cannot be represented by an ASGI scope."""
 
 
+class ClientDisconnected(OSError):  # noqa: N818
+    """Raised from the app's ``send`` once the client has disconnected.
+
+    ASGI spec version 2.4 requires that calling ``send()`` on a closed connection
+    raises a server-specific subclass of ``OSError``. An application may catch this
+    to do cleanup work before re-raising or returning with no exception.
+    """
+
+
 class UnexpectedMessageError(Exception):
     """Raised when an unexpected ASGI message type is received for the current state."""
 

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import socket
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING, Any
 
 import anyio
@@ -774,9 +774,10 @@ def _cancelled_request_app(
     """Return an app that keeps going after the client has abandoned the request.
 
     Which is what an app doing real work does: it is mid-handler when the reset
-    lands, and only finds out at its next receive(). Sending the response it had
-    already prepared is then entirely reasonable of it, and must not take the
-    connection down.
+    lands, and only finds out at its next receive(). Trying to send the response it
+    had already prepared is then entirely reasonable of it: under ASGI spec 2.4 that
+    send raises ClientDisconnected, which the app handles, and either way it must not
+    take the connection down.
     """
 
     async def _app(scope: Any, receive: Any, send: Any) -> None:  # noqa: ANN401
@@ -794,8 +795,11 @@ def _cancelled_request_app(
             if message["type"] == "http.disconnect":
                 break
         disconnected.set()
-        await send({"type": "http.response.start", "status": 200, "headers": []})
-        await send({"type": "http.response.body", "body": b"too late"})
+        # The stream is gone, so the send now raises rather than being silently
+        # dropped (ASGI spec 2.4); the app catches it and carries on.
+        with suppress(anycorn.ClientDisconnected):
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"too late"})
         responded.set()
 
     return _app
@@ -808,13 +812,14 @@ async def test_a_reset_stream_disconnects_the_app_and_is_not_written_to(
     """A client's RESET_STREAM must reach the app as a disconnect, and not break the rest.
 
     Driven by a real client abandoning a real request, so what is asserted is only
-    what a peer can observe: the app is told, it may respond anyway, and the
-    connection goes on serving other requests.
+    what a peer can observe: the app is told, its late send raises ClientDisconnected
+    which it handles (ASGI spec 2.4), and the connection goes on serving other
+    requests.
 
-    Deliberately not asserted here, because end to end cannot tell: *which* of
-    H3Protocol's two guards kept the connection up. Skipping the send and catching
-    aioquic's assertion have the same effect from outside, so removing either one
-    alone leaves this test passing. test_h3.py pins the skip itself.
+    The protocol-level guards that keep a write off a reset stream - skipping the
+    send, and catching aioquic's assertion - still exist for anything that does reach
+    the writer, and test_h3.py pins them; end to end only shows that a real reset
+    reaches the app and the connection survives the app responding into it.
 
     https://github.com/pgjones/hypercorn/issues/352
     """

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from typing import Any, cast
 from unittest.mock import call
 
+import anyio
 import pytest
 
+from anycorn.app_wrappers import ASGIWrapper
 from anycorn.config import Config
 from anycorn.protocol.events import (
     Body,
@@ -20,13 +22,17 @@ from anycorn.protocol.events import (
 )
 from anycorn.protocol.http_stream import ASGIHTTPState, HTTPStream
 from anycorn.statsd import StatsdLogger
+from anycorn.task_group import TaskGroup
 from anycorn.typing import (
+    ASGIReceiveCallable,
+    ASGISendCallable,
     ConnectionState,
     HTTPResponseBodyEvent,
     HTTPResponseStartEvent,
     HTTPScope,
+    Scope,
 )
-from anycorn.utils import UnexpectedMessageError, default_tls_extension
+from anycorn.utils import ClientDisconnected, UnexpectedMessageError, default_tls_extension
 from anycorn.worker_context import WorkerContext
 from tests.helpers import LogCapture, capture_logs
 
@@ -83,7 +89,7 @@ async def test_handle_request_http_1(stream: HTTPStream, http_version: str) -> N
     assert scope == {
         "type": "http",
         "http_version": http_version,
-        "asgi": {"spec_version": "2.1", "version": "3.0"},
+        "asgi": {"spec_version": "2.5", "version": "3.0"},
         "method": "GET",
         "scheme": "http",
         "path": "/",
@@ -115,7 +121,7 @@ async def test_handle_request_http_2(stream: HTTPStream) -> None:
     assert scope == {
         "type": "http",
         "http_version": "2",
-        "asgi": {"spec_version": "2.1", "version": "3.0"},
+        "asgi": {"spec_version": "2.5", "version": "3.0"},
         "method": "GET",
         "scheme": "http",
         "path": "/",
@@ -199,6 +205,93 @@ async def test_handle_closed(stream: HTTPStream) -> None:
     await stream.handle(StreamClosed(stream_id=1))
     stream.app_put.assert_called()  # type: ignore[attr-defined]
     assert stream.app_put.call_args_list == [call({"type": "http.disconnect"})]  # type: ignore[attr-defined]
+
+
+def _get_request() -> Request:
+    return Request(
+        stream_id=1,
+        http_version="1.1",
+        headers=[(b"host", b"anycorn")],
+        raw_path=b"/",
+        method="GET",
+        state=ConnectionState({}),
+    )
+
+
+@pytest.mark.anyio
+async def test_send_after_client_disconnect_raises(config: Config) -> None:
+    """A real app that sends after the client has gone gets ClientDisconnected (spec 2.4).
+
+    Driven through a real task group and a real ASGI app rather than poking app_send:
+    the app receives the http.disconnect, then its next send() must raise.
+    """
+    outcome: dict[str, object] = {}
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "http"
+        assert (await receive())["type"] == "http.disconnect"
+        try:
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+        except ClientDisconnected as exc:
+            outcome["raised"] = isinstance(exc, OSError)
+
+    async def send(event: Event) -> None:
+        pass
+
+    async with TaskGroup() as task_group:
+        stream = HTTPStream(
+            ASGIWrapper(app),
+            config,
+            WorkerContext(None),
+            task_group,
+            ("127.0.0.1", 1234),
+            ("127.0.0.1", 8000),
+            send,
+            1,
+            None,
+        )
+        await stream.handle(_get_request())
+        await anyio.wait_all_tasks_blocked()
+        await stream.handle(StreamClosed(stream_id=1))
+        await anyio.wait_all_tasks_blocked()
+
+    # An OSError subclass, as the spec requires, and the app really caught it.
+    assert outcome == {"raised": True}
+
+
+@pytest.mark.anyio
+async def test_client_disconnect_left_uncaught_is_not_a_framework_error(
+    config: Config, logs: LogCapture
+) -> None:
+    """The spec lets an app re-raise the disconnect; that clean exit is not logged as an error."""
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "http"
+        assert (await receive())["type"] == "http.disconnect"
+        # Do not catch: let ClientDisconnected propagate out of the app.
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    async def send(event: Event) -> None:
+        pass
+
+    async with TaskGroup() as task_group:
+        stream = HTTPStream(
+            ASGIWrapper(app),
+            config,
+            WorkerContext(None),
+            task_group,
+            ("127.0.0.1", 1234),
+            ("127.0.0.1", 8000),
+            send,
+            1,
+            None,
+        )
+        await stream.handle(_get_request())
+        await anyio.wait_all_tasks_blocked()
+        await stream.handle(StreamClosed(stream_id=1))
+        await anyio.wait_all_tasks_blocked()
+
+    assert logs.error == []
 
 
 @pytest.mark.anyio

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -343,6 +343,44 @@ async def test_pathsend_streams_the_named_file(stream: HTTPStream, tmp_path: Pat
 
 
 @pytest.mark.anyio
+async def test_lowering_the_spec_version_advertises_it_and_drops_the_raise() -> None:
+    """A configured spec_version below 2.4 is advertised, and send() no longer raises."""
+    config = Config()
+    config.asgi_spec_version = "2.3"
+    outcome: dict[str, object] = {}
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["asgi"]["spec_version"] == "2.3"
+        assert (await receive())["type"] == "http.disconnect"
+        # Below 2.4 the send after disconnect is dropped rather than raising, so the
+        # handler runs to completion instead of being interrupted.
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        outcome["completed"] = True
+
+    async def send(event: Event) -> None:
+        pass
+
+    async with TaskGroup() as task_group:
+        stream = HTTPStream(
+            ASGIWrapper(app),
+            config,
+            WorkerContext(None),
+            task_group,
+            ("127.0.0.1", 1234),
+            ("127.0.0.1", 8000),
+            send,
+            1,
+            None,
+        )
+        await stream.handle(_get_request())
+        await anyio.wait_all_tasks_blocked()
+        await stream.handle(StreamClosed(stream_id=1))
+        await anyio.wait_all_tasks_blocked()
+
+    assert outcome == {"completed": True}
+
+
+@pytest.mark.anyio
 async def test_send_response(stream: HTTPStream, logs: LogCapture) -> None:
     await stream.handle(
         Request(

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -352,6 +352,44 @@ async def test_client_disconnect_left_uncaught_is_not_a_framework_error(
 
 
 @pytest.mark.anyio
+async def test_lowering_the_spec_version_advertises_it_and_drops_the_raise() -> None:
+    """A configured spec_version below 2.4 is advertised, and send() no longer raises."""
+    config = Config()
+    config.asgi_spec_version = "2.3"
+    outcome: dict[str, object] = {}
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["asgi"]["spec_version"] == "2.3"
+        assert (await receive())["type"] == "http.disconnect"
+        # Below 2.4 the send after disconnect is dropped rather than raising, so the
+        # handler runs to completion instead of being interrupted.
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        outcome["completed"] = True
+
+    async def send(event: Event) -> None:
+        pass
+
+    async with TaskGroup() as task_group:
+        stream = HTTPStream(
+            ASGIWrapper(app),
+            config,
+            WorkerContext(None),
+            task_group,
+            ("127.0.0.1", 1234),
+            ("127.0.0.1", 8000),
+            send,
+            1,
+            None,
+        )
+        await stream.handle(_get_request())
+        await anyio.wait_all_tasks_blocked()
+        await stream.handle(StreamClosed(stream_id=1))
+        await anyio.wait_all_tasks_blocked()
+
+    assert outcome == {"completed": True}
+
+
+@pytest.mark.anyio
 async def test_send_response(stream: HTTPStream, logs: LogCapture) -> None:
     await stream.handle(
         Request(

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import call
 
+import anyio
 import pytest
 
+from anycorn.app_wrappers import ASGIWrapper
 from anycorn.config import Config
 from anycorn.protocol.events import (
     Body,
@@ -22,14 +24,18 @@ from anycorn.protocol.events import (
 from anycorn.protocol.http_stream import ASGIHTTPState, HTTPStream
 from anycorn.sendfile import have_sendfile
 from anycorn.statsd import StatsdLogger
+from anycorn.task_group import TaskGroup
 from anycorn.typing import (
+    ASGIReceiveCallable,
+    ASGISendCallable,
     ConnectionState,
     HTTPResponseBodyEvent,
     HTTPResponsePathSendEvent,
     HTTPResponseStartEvent,
     HTTPScope,
+    Scope,
 )
-from anycorn.utils import UnexpectedMessageError, default_tls_extension
+from anycorn.utils import ClientDisconnected, UnexpectedMessageError, default_tls_extension
 from anycorn.worker_context import WorkerContext
 from tests.helpers import LogCapture, capture_logs
 
@@ -94,7 +100,7 @@ async def test_handle_request_http_1(stream: HTTPStream, http_version: str) -> N
     assert scope == {
         "type": "http",
         "http_version": http_version,
-        "asgi": {"spec_version": "2.1", "version": "3.0"},
+        "asgi": {"spec_version": "2.5", "version": "3.0"},
         "method": "GET",
         "scheme": "http",
         "path": "/",
@@ -126,7 +132,7 @@ async def test_handle_request_http_2(stream: HTTPStream) -> None:
     assert scope == {
         "type": "http",
         "http_version": "2",
-        "asgi": {"spec_version": "2.1", "version": "3.0"},
+        "asgi": {"spec_version": "2.5", "version": "3.0"},
         "method": "GET",
         "scheme": "http",
         "path": "/",
@@ -267,6 +273,82 @@ async def test_pathsend_streams_the_named_file(stream: HTTPStream, tmp_path: Pat
     assert (zerocopy.offset, zerocopy.count) == (0, len(payload))
     assert any(isinstance(event, EndBody) for event in sent)
     assert any(isinstance(event, StreamClosed) for event in sent)
+
+
+@pytest.mark.anyio
+async def test_send_after_client_disconnect_raises(config: Config) -> None:
+    """A real app that sends after the client has gone gets ClientDisconnected (spec 2.4).
+
+    Driven through a real task group and a real ASGI app rather than poking app_send:
+    the app receives the http.disconnect, then its next send() must raise.
+    """
+    outcome: dict[str, object] = {}
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "http"
+        assert (await receive())["type"] == "http.disconnect"
+        try:
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+        except ClientDisconnected as exc:
+            outcome["raised"] = isinstance(exc, OSError)
+
+    async def send(event: Event) -> None:
+        pass
+
+    async with TaskGroup() as task_group:
+        stream = HTTPStream(
+            ASGIWrapper(app),
+            config,
+            WorkerContext(None),
+            task_group,
+            ("127.0.0.1", 1234),
+            ("127.0.0.1", 8000),
+            send,
+            1,
+            None,
+        )
+        await stream.handle(_get_request())
+        await anyio.wait_all_tasks_blocked()
+        await stream.handle(StreamClosed(stream_id=1))
+        await anyio.wait_all_tasks_blocked()
+
+    # An OSError subclass, as the spec requires, and the app really caught it.
+    assert outcome == {"raised": True}
+
+
+@pytest.mark.anyio
+async def test_client_disconnect_left_uncaught_is_not_a_framework_error(
+    config: Config, logs: LogCapture
+) -> None:
+    """The spec lets an app re-raise the disconnect; that clean exit is not logged as an error."""
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "http"
+        assert (await receive())["type"] == "http.disconnect"
+        # Do not catch: let ClientDisconnected propagate out of the app.
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    async def send(event: Event) -> None:
+        pass
+
+    async with TaskGroup() as task_group:
+        stream = HTTPStream(
+            ASGIWrapper(app),
+            config,
+            WorkerContext(None),
+            task_group,
+            ("127.0.0.1", 1234),
+            ("127.0.0.1", 8000),
+            send,
+            1,
+            None,
+        )
+        await stream.handle(_get_request())
+        await anyio.wait_all_tasks_blocked()
+        await stream.handle(StreamClosed(stream_id=1))
+        await anyio.wait_all_tasks_blocked()
+
+    assert logs.error == []
 
 
 @pytest.mark.anyio

--- a/tests/protocol/test_ws_stream.py
+++ b/tests/protocol/test_ws_stream.py
@@ -385,6 +385,19 @@ async def test_handle_closed(stream: WSStream) -> None:
 
 
 @pytest.mark.anyio
+async def test_disconnect_reason_is_dropped_below_spec_2_5() -> None:
+    """The disconnect reason is a 2.5 addition, so a lower advertised version omits it."""
+    config = Config()
+    config.asgi_spec_version = "2.4"
+    stream = WSStream(
+        AsyncMock(), config, WorkerContext(None), AsyncMock(), None, None, AsyncMock(), 1, None
+    )
+    stream.app_put = AsyncMock()
+    await stream.handle(StreamClosed(stream_id=1))
+    assert stream.app_put.call_args_list == [call({"type": "websocket.disconnect", "code": 1006})]
+
+
+@pytest.mark.anyio
 async def test_handle_client_close_reports_its_code(stream: WSStream) -> None:
     """A clean client close must reach the app as its own code, not 1006.
 

--- a/tests/protocol/test_ws_stream.py
+++ b/tests/protocol/test_ws_stream.py
@@ -13,8 +13,18 @@ import wsproto.connection
 import wsproto.events
 from wsproto.events import BytesMessage, TextMessage
 
+from anycorn.app_wrappers import ASGIWrapper
 from anycorn.config import Config
-from anycorn.protocol.events import Body, Data, EndBody, EndData, Request, Response, StreamClosed
+from anycorn.protocol.events import (
+    Body,
+    Data,
+    EndBody,
+    EndData,
+    Event,
+    Request,
+    Response,
+    StreamClosed,
+)
 from anycorn.protocol.ws_stream import (
     ASGIWebsocketState,
     FrameTooLargeError,
@@ -24,14 +34,17 @@ from anycorn.protocol.ws_stream import (
 )
 from anycorn.task_group import TaskGroup
 from anycorn.typing import (
+    ASGIReceiveCallable,
+    ASGISendCallable,
     ConnectionState,
+    Scope,
     WebsocketAcceptEvent,
     WebsocketCloseEvent,
     WebsocketResponseBodyEvent,
     WebsocketResponseStartEvent,
     WebsocketSendEvent,
 )
-from anycorn.utils import UnexpectedMessageError, default_tls_extension
+from anycorn.utils import ClientDisconnected, UnexpectedMessageError, default_tls_extension
 from anycorn.worker_context import WorkerContext
 from tests.helpers import LogCapture, capture_logs
 
@@ -215,7 +228,7 @@ async def test_handle_request(stream: WSStream) -> None:
     scope = stream.task_group.spawn_app.call_args[0][2]  # type: ignore[attr-defined]
     assert scope == {
         "type": "websocket",
-        "asgi": {"spec_version": "2.3", "version": "3.0"},
+        "asgi": {"spec_version": "2.5", "version": "3.0"},
         "scheme": "ws",
         "http_version": "2",
         "path": "/",
@@ -366,7 +379,9 @@ async def test_handle_connection(stream: WSStream) -> None:
 async def test_handle_closed(stream: WSStream) -> None:
     await stream.handle(StreamClosed(stream_id=1))
     stream.app_put.assert_called()  # type: ignore[attr-defined]
-    assert stream.app_put.call_args_list == [call({"type": "websocket.disconnect", "code": 1006})]  # type: ignore[attr-defined]
+    assert stream.app_put.call_args_list == [  # type: ignore[unresolved-attribute]
+        call({"type": "websocket.disconnect", "code": 1006, "reason": None})
+    ]
 
 
 @pytest.mark.anyio
@@ -397,7 +412,35 @@ async def test_handle_client_close_reports_its_code(stream: WSStream) -> None:
     await stream.handle(Data(stream_id=1, data=b"\x88\x82\x00\x00\x00\x00\x03\xe8"))
     await stream.handle(StreamClosed(stream_id=1))
 
-    assert stream.app_put.call_args_list == [call({"type": "websocket.disconnect", "code": 1000})]
+    assert stream.app_put.call_args_list == [
+        call({"type": "websocket.disconnect", "code": 1000, "reason": ""})
+    ]
+
+
+@pytest.mark.anyio
+async def test_handle_client_close_reports_its_reason(stream: WSStream) -> None:
+    """A close frame's reason text reaches the app on the disconnect event (spec 2.5)."""
+    await stream.handle(
+        Request(
+            stream_id=1,
+            http_version="2",
+            headers=[(b"sec-websocket-version", b"13")],
+            raw_path=b"/",
+            method="GET",
+            state=ConnectionState({}),
+        )
+    )
+    await stream.app_send(cast("WebsocketAcceptEvent", {"type": "websocket.accept"}))
+    stream.app_put = AsyncMock()
+
+    # A masked client close frame (zero mask key) carrying code 1001 (0x03e9) and the
+    # reason text "bye".
+    await stream.handle(Data(stream_id=1, data=b"\x88\x85\x00\x00\x00\x00\x03\xe9bye"))
+    await stream.handle(StreamClosed(stream_id=1))
+
+    assert stream.app_put.call_args_list == [
+        call({"type": "websocket.disconnect", "code": 1001, "reason": "bye"})
+    ]
 
 
 @pytest.mark.anyio
@@ -719,14 +762,67 @@ async def test_closure(stream: WSStream) -> None:
     assert stream.closed
     # It is important that the disconnect message has only been sent
     # once.
-    assert stream.app_put.call_args_list == [call({"type": "websocket.disconnect", "code": 1006})]  # type: ignore[unresolved-attribute]
+    assert stream.app_put.call_args_list == [  # type: ignore[unresolved-attribute]
+        call({"type": "websocket.disconnect", "code": 1006, "reason": None})
+    ]
 
 
 @pytest.mark.anyio
-async def test_closed_app_send_noop(stream: WSStream) -> None:
-    stream.closed = True
-    await stream.app_send(cast("WebsocketAcceptEvent", {"type": "websocket.accept"}))
-    stream.send.assert_not_called()  # type: ignore[attr-defined]
+async def test_send_after_client_disconnect_raises(config: Config) -> None:
+    """A real app that sends after the client has gone gets ClientDisconnected (spec 2.4).
+
+    Driven through a real task group and a real ASGI app: the app accepts, receives the
+    websocket.disconnect, then its next send() must raise.
+    """
+    outcome: dict[str, object] = {}
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "websocket"
+        assert (await receive())["type"] == "websocket.connect"
+        accept: WebsocketAcceptEvent = {
+            "type": "websocket.accept",
+            "subprotocol": None,
+            "headers": [],
+        }
+        await send(accept)
+        assert (await receive())["type"] == "websocket.disconnect"
+        late: WebsocketSendEvent = {"type": "websocket.send", "bytes": None, "text": "late"}
+        try:
+            await send(late)
+        except ClientDisconnected as exc:
+            outcome["raised"] = isinstance(exc, OSError)
+
+    async def send(event: Event) -> None:
+        pass
+
+    async with TaskGroup() as task_group:
+        stream = WSStream(
+            ASGIWrapper(app),
+            config,
+            WorkerContext(None),
+            task_group,
+            ("127.0.0.1", 1234),
+            ("127.0.0.1", 8000),
+            send,
+            1,
+            None,
+        )
+        await stream.handle(
+            Request(
+                stream_id=1,
+                http_version="2",
+                headers=[(b"sec-websocket-version", b"13")],
+                raw_path=b"/",
+                method="GET",
+                state=ConnectionState({}),
+            )
+        )
+        await anyio.wait_all_tasks_blocked()
+        await stream.handle(StreamClosed(stream_id=1))
+        await anyio.wait_all_tasks_blocked()
+
+    # An OSError subclass, as the spec requires, and the app really caught it.
+    assert outcome == {"raised": True}
 
 
 @pytest.mark.anyio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,6 +19,7 @@ from anycorn.utils import (
     default_tls_extension,
     filter_pseudo_headers,
     is_asgi,
+    parse_spec_version,
     raise_shutdown,
     suppress_body,
 )
@@ -216,3 +217,17 @@ async def test_raise_shutdown_without_a_callback() -> None:
 
     with pytest.raises(ShutdownError):
         await raise_shutdown(trigger)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("2.0", (2, 0)), ("2.4", (2, 4)), ("2.5", (2, 5))],
+)
+def test_parse_spec_version_accepts_known_versions(value: str, expected: tuple[int, int]) -> None:
+    assert parse_spec_version(value) == expected
+
+
+@pytest.mark.parametrize("value", ["2.6", "3.0", "2", "banana", ""])
+def test_parse_spec_version_rejects_unknown(value: str) -> None:
+    with pytest.raises(ValueError, match="Unknown ASGI spec_version"):
+        parse_spec_version(value)


### PR DESCRIPTION
Starlette (and any ASGI app) can only learn a client has gone mid-response if the server tells it. ASGI grew two mechanisms for this that anycorn did not implement: spec 2.4 says a send() on a closed connection raises a server-specific subclass of OSError, and spec 2.5 carries the peer's close reason on the WebSocket disconnect event. anycorn advertised 2.1 (HTTP) and 2.3 (WebSocket) and its send path stayed silent after a disconnect, so a streaming handler wrote into the void with no way to notice.

Add a ClientDisconnected(OSError) and raise it from HTTPStream.app_send and WSStream.app_send once the stream is closed. The None sentinel - the app finishing rather than sending - is returned first, so cleanup is unaffected; only a real send() after the client has gone raises. This is the same signal uvicorn gives, and it is what lets Starlette's StreamingResponse take its spec_version >= (2, 4) path instead of a background disconnect listener.

An app may catch this to clean up, or let it propagate ("re-raising it", as the spec puts it). So _handle treats a ClientDisconnected that escapes the app as a normal end rather than logging it as a framework error.

Record the peer's close reason alongside its code and surface it on websocket.disconnect (spec 2.5); WebsocketDisconnectEvent gains the reason key. With the send() behaviour and the close reason in place, both the HTTP and WebSocket scopes now honestly advertise spec_version 2.5.

Drive the new behaviour through a real task group and a real ASGI app rather than poking app_send: a handler that sends after the client disconnects gets ClientDisconnected, an uncaught one is not logged as an error, and a peer close reason reaches the app.


Claude-Session: https://claude.ai/code/session_01Vj7g3wZVnvhA4hskudChZA