### PR TITLE
Implement the ASGI Path Send extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version history
 
+## Unreleased
+
+- Implement the Path Send extension (`http.response.pathsend`), streaming a file the
+  app names by path as the response body on any HTTP version.
+
 ## 0.20.0
 
 - Hold websocket data that arrives before the app accepts.

--- a/src/anycorn/protocol/http_stream.py
+++ b/src/anycorn/protocol/http_stream.py
@@ -6,6 +6,8 @@ from enum import Enum, auto
 from time import time
 from typing import TYPE_CHECKING
 
+import anyio
+
 from anycorn.typing import (
     AppWrapper,
     ASGIReceiveEvent,
@@ -48,6 +50,7 @@ if TYPE_CHECKING:
 TRAILERS_VERSIONS = {"2", "3"}
 PUSH_VERSIONS = {"2", "3"}
 EARLY_HINTS_VERSIONS = {"2", "3"}
+PATHSEND_CHUNK_SIZE = 65536
 
 
 class ASGIHTTPState(Enum):
@@ -132,6 +135,10 @@ class HTTPStream:
             if event.http_version in EARLY_HINTS_VERSIONS:
                 extensions["http.response.early_hint"] = {}
 
+            # Path send just streams a file from disk as the body, so it works on
+            # every HTTP version rather than being tied to h2/h3 features above.
+            extensions["http.response.pathsend"] = {}
+
             self.scope = HTTPScope(
                 type="http",
                 http_version=event.http_version,
@@ -182,7 +189,7 @@ class HTTPStream:
             if self.app_put is not None:
                 await self.app_put({"type": "http.disconnect"})
 
-    async def app_send(self, message: ASGISendEvent | None) -> None:  # noqa: C901, PLR0912
+    async def app_send(self, message: ASGISendEvent | None) -> None:  # noqa: C901, PLR0912, PLR0915
         """Handle a message sent by the ASGI application."""
         if message is None:  # ASGI App has finished sending messages
             if not self.closed:
@@ -251,6 +258,8 @@ class HTTPStream:
                     self.state = ASGIHTTPState.TRAILERS
                 else:
                     await self._send_closed()
+        elif message["type"] == "http.response.pathsend" and self.state == ASGIHTTPState.RESPONSE:
+            await self._send_pathsend(message["path"])
         elif (
             message["type"] == "http.response.trailers"
             and self.scope["http_version"] in TRAILERS_VERSIONS
@@ -295,6 +304,20 @@ class HTTPStream:
                 await self._send_closed()
         else:
             raise UnexpectedMessageError(self.state, message["type"])
+
+    async def _send_pathsend(self, path: str) -> None:
+        # Path send names a file the app has already set Content-Length for; the
+        # server reads it out as the body. It is the terminal body message, so it
+        # finishes the response exactly as an http.response.body with more_body False.
+        if not suppress_body(self.scope["method"], int(self.response["status"])):
+            async with await anyio.open_file(path, "rb") as file_:
+                while chunk := await file_.read(PATHSEND_CHUNK_SIZE):
+                    await self.send(Body(stream_id=self.stream_id, data=chunk))
+
+        if self.response.get("trailers", False):
+            self.state = ASGIHTTPState.TRAILERS
+        else:
+            await self._send_closed()
 
     async def _send_closed(self) -> None:
         # Mark CLOSED before the first await: a StreamClosed event handled while

--- a/src/anycorn/typing.py
+++ b/src/anycorn/typing.py
@@ -61,6 +61,7 @@ Extensions = TypedDict(
     {
         "tls": TLSExtension,
         "http.response.push": Mapping[str, Any],
+        "http.response.pathsend": Mapping[str, Any],
         "http.response.trailers": Mapping[str, Any],
         "http.response.early_hint": Mapping[str, Any],
         "websocket.http.response": Mapping[str, Any],
@@ -165,6 +166,13 @@ class HTTPEarlyHintEvent(TypedDict):
 
     type: Literal["http.response.early_hint"]
     links: Iterable[bytes]
+
+
+class HTTPResponsePathSendEvent(TypedDict):
+    """ASGI HTTP path send event (``http.response.pathsend`` extension)."""
+
+    type: Literal["http.response.pathsend"]
+    path: str
 
 
 class HTTPDisconnectEvent(TypedDict):
@@ -289,6 +297,7 @@ ASGISendEvent = (
     | HTTPResponseTrailersEvent
     | HTTPServerPushEvent
     | HTTPEarlyHintEvent
+    | HTTPResponsePathSendEvent
     | HTTPDisconnectEvent
     | WebsocketAcceptEvent
     | WebsocketSendEvent

--- a/tests/protocol/test_http_stream.py
+++ b/tests/protocol/test_http_stream.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import call
 
 import pytest
@@ -23,12 +23,16 @@ from anycorn.statsd import StatsdLogger
 from anycorn.typing import (
     ConnectionState,
     HTTPResponseBodyEvent,
+    HTTPResponsePathSendEvent,
     HTTPResponseStartEvent,
     HTTPScope,
 )
 from anycorn.utils import UnexpectedMessageError, default_tls_extension
 from anycorn.worker_context import WorkerContext
 from tests.helpers import LogCapture, capture_logs
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 try:
     from unittest.mock import AsyncMock
@@ -93,7 +97,7 @@ async def test_handle_request_http_1(stream: HTTPStream, http_version: str) -> N
         "headers": [],
         "client": None,
         "server": None,
-        "extensions": {},
+        "extensions": {"http.response.pathsend": {}},
         "state": ConnectionState({}),
     }
 
@@ -129,6 +133,7 @@ async def test_handle_request_http_2(stream: HTTPStream) -> None:
             "http.response.trailers": {},
             "http.response.early_hint": {},
             "http.response.push": {},
+            "http.response.pathsend": {},
         },
         "state": ConnectionState({}),
     }
@@ -199,6 +204,60 @@ async def test_handle_closed(stream: HTTPStream) -> None:
     await stream.handle(StreamClosed(stream_id=1))
     stream.app_put.assert_called()  # type: ignore[attr-defined]
     assert stream.app_put.call_args_list == [call({"type": "http.disconnect"})]  # type: ignore[attr-defined]
+
+
+def _get_request() -> Request:
+    return Request(
+        stream_id=1,
+        http_version="1.1",
+        headers=[(b"host", b"anycorn")],
+        raw_path=b"/",
+        method="GET",
+        state=ConnectionState({}),
+    )
+
+
+@pytest.mark.anyio
+async def test_pathsend_extension_is_advertised(stream: HTTPStream) -> None:
+    """Path send is protocol-agnostic, so it is offered on HTTP/1.1 too."""
+    await stream.handle(_get_request())
+    scope = stream.task_group.spawn_app.call_args[0][2]  # type: ignore[attr-defined]
+    assert scope["extensions"]["http.response.pathsend"] == {}
+
+
+@pytest.mark.anyio
+async def test_pathsend_streams_the_named_file(stream: HTTPStream, tmp_path: Path) -> None:
+    """A pathsend message streams the file at that path as the response body, then closes."""
+    sent: list[Event] = []
+
+    async def send(event: Event) -> None:
+        sent.append(event)
+
+    stream.send = send  # a real collector rather than the fixture's mock
+    await stream.handle(_get_request())
+
+    payload = b"the quick brown fox\n" * 5000  # larger than PATHSEND_CHUNK_SIZE
+    file_path = tmp_path / "payload.bin"
+    file_path.write_bytes(payload)
+
+    await stream.app_send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-length", str(len(payload)).encode())],
+        }
+    )
+    pathsend: HTTPResponsePathSendEvent = {
+        "type": "http.response.pathsend",
+        "path": str(file_path),
+    }
+    await stream.app_send(pathsend)
+
+    # The whole file went out as body, and the response was finished off.
+    body = b"".join(event.data for event in sent if isinstance(event, Body))
+    assert body == payload
+    assert any(isinstance(event, EndBody) for event in sent)
+    assert any(isinstance(event, StreamClosed) for event in sent)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Path Send (http.response.pathsend) lets an app name a file by path and have the server stream it as the response body, having set Content-Length itself. It is offered on every HTTP version, since - unlike zero-copy send - it needs no OS support: the server just reads the file out through the ordinary body path, so it works the same over h11, h2 and h3, with or without TLS.

Advertise the extension in the HTTP scope, and on http.response.pathsend open the named file and send it as the body before finishing the response as a final http.response.body would. Starlette's FileResponse uses this when the server offers it, saving the framework from reading the file itself.


Claude-Session: https://claude.ai/code/session_01Vj7g3wZVnvhA4hskudChZA