### PR TITLE
Fix CONNECT routing and WebSocket teardown over HTTP/2 and HTTP/3

### DIFF
--- a/src/anycorn/protocol/h2.py
+++ b/src/anycorn/protocol/h2.py
@@ -174,8 +174,11 @@ class H2Protocol:
         if headers is not None:
             event = h2.events.RequestReceived(stream_id=1)
             event.headers = headers
-            await self._create_stream(event)
-            await self.streams[event.stream_id].handle(EndBody(stream_id=event.stream_id))
+            # An h2c upgrade carries whatever method the HTTP/1.1 request used, so this
+            # can be a CONNECT that is answered rather than served - there is then no
+            # stream to end the body of.
+            if await self._create_stream(event):
+                await self.streams[event.stream_id].handle(EndBody(stream_id=event.stream_id))
         self.task_group.spawn(self.send_task)
 
     async def send_task(self) -> None:
@@ -287,8 +290,7 @@ class H2Protocol:
                     self.connection.update_settings(
                         {h2.settings.SettingCodes.MAX_CONCURRENT_STREAMS: 0}
                     )
-                else:
-                    await self._create_stream(event)
+                elif await self._create_stream(event):
                     await self.send(Updated(idle=False))
 
                 if self.keep_alive_requests > self.config.keep_alive_max_requests:
@@ -364,20 +366,31 @@ class H2Protocol:
             self.priority.block(event.stream_id)
         await self.has_data.set()
 
-    async def _create_stream(self, request: h2.events.RequestReceived) -> None:
+    async def _create_stream(self, request: h2.events.RequestReceived) -> bool:
+        """Hand the request to a new stream, returning whether one was created."""
         # Defaulted in step with the h3 handler: guard against a CONNECT reaching here
         # without a :path. The h2 library rejects that before it arrives (no stream is
         # created), so this is defensive only rather than the live crash it is over
         # HTTP/3.
         method = ""
         raw_path = b""
+        protocol = None
         for name, value in request.headers:
             if name == b":method":
                 method = value.decode("ascii").upper()
             elif name == b":path":
                 raw_path = value
+            elif name == b":protocol":
+                protocol = value.lower()
 
         if method == "CONNECT":
+            if protocol != b"websocket":
+                # WebSockets are the only protocol this server tunnels, and this is
+                # not a forward proxy, so a CONNECT naming anything else - or naming
+                # nothing, which is a request for a plain TCP tunnel - is turned away.
+                # RFC 8441 s4 and RFC 9113 s8.5 both say 501 for exactly this.
+                await self._reject_connect(request.stream_id)
+                return False
             self.streams[request.stream_id] = WSStream(
                 self.app,
                 self.config,
@@ -423,6 +436,20 @@ class H2Protocol:
         )
         self.keep_alive_requests += 1
         await self.context.mark_request()
+        return True
+
+    async def _reject_connect(self, stream_id: int) -> None:
+        """Answer a CONNECT this server will not tunnel, without opening a stream."""
+        self.connection.send_headers(
+            stream_id,
+            [
+                (b":status", b"501"),
+                (b"content-length", b"0"),
+                *self.config.response_headers("h2"),
+            ],
+            end_stream=True,
+        )
+        await self._flush()
 
     async def _create_server_push(
         self, stream_id: int, path: bytes, headers: list[tuple[bytes, bytes]]
@@ -447,8 +474,8 @@ class H2Protocol:
             event.headers = request_headers
             # Counted towards keep_alive_requests once, by _create_stream, like any
             # other request - not again here.
-            await self._create_stream(event)
-            await self.streams[event.stream_id].handle(EndBody(stream_id=event.stream_id))
+            if await self._create_stream(event):
+                await self.streams[event.stream_id].handle(EndBody(stream_id=event.stream_id))
 
     async def _close_stream(self, stream_id: int) -> None:
         if stream_id in self.streams:

--- a/src/anycorn/protocol/h3.py
+++ b/src/anycorn/protocol/h3.py
@@ -160,13 +160,25 @@ class H3Protocol:
         # 400 instead.
         method = ""
         raw_path = b""
+        protocol = None
         for name, value in request.headers:
             if name == b":method":
                 method = value.decode("ascii").upper()
             elif name == b":path":
                 raw_path = value
+            elif name == b":protocol":
+                protocol = value.lower()
 
         if method == "CONNECT":
+            if protocol != b"websocket":
+                # WebSockets are the only protocol this server tunnels, and this is
+                # not a forward proxy, so a CONNECT naming anything else - or naming
+                # nothing, which is a request for a plain tunnel - is turned away.
+                # RFC 9220 carries RFC 8441's 501 for this over to HTTP/3. aioquic
+                # requires only :method and :authority, so unlike h2 it hands such a
+                # request straight here rather than rejecting it first.
+                await self._reject_connect(request.stream_id)
+                return
             self.streams[request.stream_id] = WSStream(
                 self.app,
                 self.config,
@@ -202,6 +214,19 @@ class H3Protocol:
             )
         )
         await self.context.mark_request()
+
+    async def _reject_connect(self, stream_id: int) -> None:
+        """Answer a CONNECT this server will not tunnel, without opening a stream."""
+        self.connection.send_headers(
+            stream_id,
+            [
+                (b":status", b"501"),
+                (b"content-length", b"0"),
+                *self.config.response_headers("h3"),
+            ],
+            end_stream=True,
+        )
+        await self.send()
 
     async def _create_server_push(
         self, stream_id: int, path: bytes, headers: list[tuple[bytes, bytes]]

--- a/src/anycorn/protocol/h3.py
+++ b/src/anycorn/protocol/h3.py
@@ -108,8 +108,14 @@ class H3Protocol:
     async def stream_send(self, event: StreamEvent) -> None:
         """Send a stream event to the remote client."""
         if isinstance(event, StreamClosed):
-            self.streams.pop(event.stream_id, None)
+            stream = self.streams.pop(event.stream_id, None)
             self._reset_streams.discard(event.stream_id)
+            if stream is not None:
+                # Handed back to the stream, as h2 does and as _reset_stream does here,
+                # so it knows it is closed and the app hears the disconnect. Popping it
+                # and no more left a WebSocket that closed itself - which is how every
+                # WebSocket ends - with an app still waiting on receive() for ever.
+                await stream.handle(event)
             return
         if isinstance(event, Request):
             await self._create_server_push(event.stream_id, event.raw_path, event.headers)

--- a/src/anycorn/protocol/ws_stream.py
+++ b/src/anycorn/protocol/ws_stream.py
@@ -323,6 +323,8 @@ class WSStream:
         elif isinstance(event, (Body, Data)):
             self.connection.receive_data(event.data)
             await self._handle_events()
+        elif isinstance(event, (EndBody, EndData)):
+            await self._peer_ended_stream()
         elif isinstance(event, StreamClosed):
             self.closed = True
             if self.app_put is not None:
@@ -399,6 +401,28 @@ class WSStream:
         else:
             raise UnexpectedMessageError(self.state, message["type"])
 
+    async def _peer_ended_stream(self) -> None:
+        """Close the WebSocket, the peer having ended its side of the stream.
+
+        Over HTTP/2 and HTTP/3 that is what a TCP close is over HTTP/1.1 (RFC 8441
+        s5.3). Left unhandled the app never heard the disconnect and the stream never
+        went idle, so the connection could not be reclaimed either. h11 swaps in a
+        pass-through connection the moment it sees the upgrade, so a WebSocket there
+        is never sent one of these.
+        """
+        if self.state == ASGIWebsocketState.CONNECTED:
+            self.state = ASGIWebsocketState.CLOSED
+            # End our side too, rather than leaving the stream half open with its send
+            # buffer and its place in the priority tree outliving it.
+            await self.send(EndData(stream_id=self.stream_id))
+            await self.send(StreamClosed(stream_id=self.stream_id))
+        elif self.state == ASGIWebsocketState.HANDSHAKE:
+            # The peer gave up before the handshake resolved, so there is nothing left
+            # for the app to accept onto.
+            await self._send_error_response(400)
+        else:
+            await self.send(StreamClosed(stream_id=self.stream_id))
+
     async def _handle_events(self) -> None:
         for event in self.connection.events():
             if isinstance(event, Message):
@@ -423,6 +447,13 @@ class WSStream:
                 self.close_code = event.code
                 if self.connection.state == ConnectionState.REMOTE_CLOSING:
                     await self._send_wsproto_event(event.response())
+                self.state = ASGIWebsocketState.CLOSED
+                # End our side as well, as the app-initiated close does. Over HTTP/1.1
+                # this is ignored and the connection is torn down regardless, but over
+                # HTTP/2 and HTTP/3 the stream would otherwise be left half open: the
+                # peer never sees it end, and its send buffer and place in the priority
+                # tree outlive it for as long as the connection lasts.
+                await self.send(EndData(stream_id=self.stream_id))
                 await self.send(StreamClosed(stream_id=self.stream_id))
 
     async def _send_error_response(self, status_code: int) -> None:

--- a/tests/e2e/test_h2_websocket.py
+++ b/tests/e2e/test_h2_websocket.py
@@ -1,0 +1,274 @@
+"""End-to-end WebSocket over HTTP/2, on a real TLS socket.
+
+The extended CONNECT of RFC 8441 is what Chrome and Firefox use for every WebSocket
+they open on an HTTP/2 connection, and it only exists over TLS in practice - ALPN is
+how the connection became HTTP/2 in the first place. Driving it over a real socket,
+with a real certificate from trustme, is the only way to know that the whole path
+holds: ALPN, the SETTINGS that permit extended CONNECT at all, the CONNECT itself,
+and WebSocket frames in DATA either way.
+
+https://github.com/mattermost/mattermost/issues/30285 is what this looks like when
+the server does not do it: Safari, which upgrades over HTTP/1.1, connects, while
+Chrome and Firefox fail with a 1006.
+"""
+
+from __future__ import annotations
+
+import ssl
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+import anyio
+import anyio.streams.tls
+import h2.config
+import h2.connection
+import h2.events
+import h2.settings
+import pytest
+import wsproto.connection
+import wsproto.events
+
+from anycorn.app_wrappers import ASGIWrapper
+from anycorn.config import Config
+from anycorn.run import worker_serve
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+    from anyio.streams.tls import TLSStream
+
+    from tests.conftest import TLSCerts
+
+HOST = "127.0.0.1"
+
+
+class _H2Client:
+    """An HTTP/2 client over a real TLS stream, reading only as far as it is asked to."""
+
+    def __init__(self, stream: TLSStream) -> None:
+        self.stream = stream
+        self.connection = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=True, header_encoding=None)
+        )
+        self._events: list[h2.events.Event] = []
+
+    async def initiate(self) -> None:
+        self.connection.initiate_connection()
+        await self.flush()
+
+    async def flush(self) -> None:
+        data = self.connection.data_to_send()
+        if data:
+            await self.stream.send(data)
+
+    async def next_event(self, kind: type[h2.events.Event]) -> Any:  # noqa: ANN401
+        """Read until an event of *kind* arrives, and return it.
+
+        Events of other kinds are kept, so a caller asking for what comes later does
+        not lose what arrived alongside what it asked for first.
+        """
+        while True:
+            for index, event in enumerate(self._events):
+                if isinstance(event, kind):
+                    del self._events[index]
+                    return event
+            self._events.extend(self.connection.receive_data(await self.stream.receive()))
+            await self.flush()
+
+
+async def _serve_lifespan(receive: Any, send: Any) -> None:  # noqa: ANN401
+    """Answer the lifespan protocol, so the server does not log its way past it."""
+    while True:
+        message = await receive()
+        if message["type"] == "lifespan.startup":
+            await send({"type": "lifespan.startup.complete"})
+        elif message["type"] == "lifespan.shutdown":
+            await send({"type": "lifespan.shutdown.complete"})
+            return
+
+
+def _client_context(tls_certs: TLSCerts) -> ssl.SSLContext:
+    context = ssl.create_default_context(cafile=str(tls_certs.cafile))
+    context.set_alpn_protocols(["h2"])
+    return context
+
+
+@asynccontextmanager
+async def _serve(app: Callable, tls_certs: TLSCerts) -> AsyncIterator[TLSStream]:
+    """Run a real server over TLS and yield a raw HTTP/2 connection to it."""
+    config = Config()
+    config.bind = [f"{HOST}:0"]  # OS-assigned; the bound URL comes back via task_status
+    config.certfile = str(tls_certs.certfile)
+    config.keyfile = str(tls_certs.keyfile)
+    config.alpn_protocols = ["h2"]
+    config.accesslog = "-"
+    config.errorlog = "-"
+
+    shutdown = anyio.Event()
+    async with anyio.create_task_group() as task_group:
+        binds: list[str] = await task_group.start(
+            lambda *, task_status: worker_serve(
+                ASGIWrapper(app), config, shutdown_trigger=shutdown.wait, task_status=task_status
+            )
+        )
+        port = urlsplit(binds[0]).port
+        assert port is not None
+        stream = await anyio.connect_tcp(
+            HOST,
+            port,
+            ssl_context=_client_context(tls_certs),
+            tls_hostname=HOST,
+            # The server is torn down under the client, so a close_notify from it is
+            # not something to wait on
+            tls_standard_compatible=False,
+        )
+        try:
+            yield stream
+        finally:
+            await stream.aclose()
+            shutdown.set()
+
+
+WEBSOCKET_CONNECT_HEADERS = [
+    (b":method", b"CONNECT"),
+    (b":protocol", b"websocket"),
+    (b":scheme", b"https"),
+    (b":authority", HOST.encode()),
+    (b":path", b"/chat?a=b"),
+    (b"sec-websocket-version", b"13"),
+]
+
+
+@pytest.mark.anyio
+async def test_websocket_over_a_real_http2_tls_connection(tls_certs: TLSCerts) -> None:
+    """A browser's WebSocket handshake, end to end over ALPN-negotiated HTTP/2."""
+    scopes: list[dict] = []
+
+    async def echo(scope: Any, receive: Any, send: Any) -> None:  # noqa: ANN401
+        if scope["type"] == "lifespan":
+            await _serve_lifespan(receive, send)
+            return
+        scopes.append(dict(scope))
+        assert (await receive())["type"] == "websocket.connect"
+        await send({"type": "websocket.accept"})
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.receive":
+                await send({"type": "websocket.send", "text": message["text"].upper()})
+            else:
+                return
+
+    with anyio.fail_after(30):
+        async with _serve(echo, tls_certs) as stream:
+            assert stream.extra(anyio.streams.tls.TLSAttribute.alpn_protocol) == "h2"  # noqa: S610
+            client = _H2Client(stream)
+            await client.initiate()
+
+            # Without this setting a browser will not send an extended CONNECT at all
+            settings = await client.next_event(h2.events.RemoteSettingsChanged)
+            enabled = settings.changed_settings[h2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL]
+            assert enabled.new_value == 1
+
+            stream_id = client.connection.get_next_available_stream_id()
+            client.connection.send_headers(stream_id, WEBSOCKET_CONNECT_HEADERS)
+            await client.flush()
+
+            response = await client.next_event(h2.events.ResponseReceived)
+            assert dict(response.headers)[b":status"] == b"200"
+
+            websocket = wsproto.connection.Connection(wsproto.connection.ConnectionType.CLIENT)
+            client.connection.send_data(
+                stream_id, websocket.send(wsproto.events.TextMessage(data="hello"))
+            )
+            await client.flush()
+
+            data = await client.next_event(h2.events.DataReceived)
+            websocket.receive_data(data.data)
+            assert list(websocket.events()) == [
+                wsproto.events.TextMessage(data="HELLO", frame_finished=True, message_finished=True)
+            ]
+
+            client.connection.send_data(
+                stream_id, websocket.send(wsproto.events.CloseConnection(code=1000))
+            )
+            await client.flush()
+
+            data = await client.next_event(h2.events.DataReceived)
+            websocket.receive_data(data.data)
+            assert list(websocket.events()) == [
+                wsproto.events.CloseConnection(code=1000, reason="")
+            ]
+            await client.next_event(h2.events.StreamEnded)
+
+    assert len(scopes) == 1
+    scope = scopes[0]
+    assert scope["type"] == "websocket"
+    assert scope["http_version"] == "2"
+    # wss, since the connection really is TLS - what the app checks to know the
+    # WebSocket is secure
+    assert scope["scheme"] == "wss"
+    assert scope["path"] == "/chat"
+    assert scope["query_string"] == b"a=b"
+    assert "tls" in scope["extensions"]
+    # RFC 8441 s5.1: none of the HTTP/1.1 handshake headers are used
+    assert dict(scope["headers"]).keys() == {b"host", b"sec-websocket-version"}
+
+
+@pytest.mark.anyio
+async def test_connect_without_the_websocket_protocol_is_not_implemented(
+    tls_certs: TLSCerts,
+) -> None:
+    """A plain tunnel CONNECT is refused, over the same real connection.
+
+    Every CONNECT used to be served as a WebSocket, so this came back as the 400 of a
+    malformed handshake from a server that is not a forward proxy at all.
+    """
+    seen: list[str] = []
+
+    async def app(scope: Any, receive: Any, send: Any) -> None:  # noqa: ANN401
+        if scope["type"] == "lifespan":
+            await _serve_lifespan(receive, send)
+            return
+        seen.append(scope["type"])
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    with anyio.fail_after(30):
+        async with _serve(app, tls_certs) as stream:
+            client = _H2Client(stream)
+            await client.initiate()
+
+            stream_id = client.connection.get_next_available_stream_id()
+            client.connection.send_headers(
+                stream_id,
+                [
+                    (b":method", b"CONNECT"),
+                    (b":scheme", b"https"),
+                    (b":authority", HOST.encode()),
+                    (b":path", b"/chat"),
+                ],
+            )
+            await client.flush()
+
+            response = await client.next_event(h2.events.ResponseReceived)
+            assert dict(response.headers)[b":status"] == b"501"
+
+            # The connection is still good, rather than having been taken down with it
+            stream_id = client.connection.get_next_available_stream_id()
+            client.connection.send_headers(
+                stream_id,
+                [
+                    (b":method", b"GET"),
+                    (b":scheme", b"https"),
+                    (b":authority", HOST.encode()),
+                    (b":path", b"/after"),
+                ],
+                end_stream=True,
+            )
+            await client.flush()
+
+            response = await client.next_event(h2.events.ResponseReceived)
+            assert dict(response.headers)[b":status"] == b"200"
+
+    assert seen == ["http"]

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 import anyio
 import httpx2
 import pytest
+import wsproto.connection
+import wsproto.events
 from aioquic.h3.connection import H3_ALPN, H3Connection
 from aioquic.h3.events import DataReceived, HeadersReceived
 from aioquic.quic.configuration import QuicConfiguration
@@ -239,6 +241,68 @@ class _H3Transport(httpx2.AsyncBaseTransport):
         )
         await self._transmit()
         return stream_id
+
+    async def open_websocket(self, path: bytes) -> tuple[int, int]:
+        """Send the extended CONNECT of RFC 8441/9220, returning the stream id and status.
+
+        This is the handshake a browser sends for a WebSocket on an HTTP/3 connection -
+        a CONNECT naming :protocol websocket, with the stream left open for the frames
+        that follow.
+        """
+        stream_id = self._quic.get_next_available_stream_id()
+        self._read_queue[stream_id] = []
+        self._read_ready[stream_id] = anyio.Event()
+        self._http.send_headers(
+            stream_id=stream_id,
+            headers=[
+                (b":method", b"CONNECT"),
+                (b":protocol", b"websocket"),
+                (b":scheme", b"https"),
+                (b":authority", self._address[0].encode()),
+                (b":path", path),
+                (b"sec-websocket-version", b"13"),
+            ],
+            end_stream=False,
+        )
+        await self._transmit()
+
+        status_code, _, _ = await self._receive_response(stream_id)
+        return stream_id, status_code
+
+    async def connect_with_protocol(self, protocol: bytes) -> int:
+        """Send an extended CONNECT naming *protocol*, and return the status."""
+        stream_id = self._quic.get_next_available_stream_id()
+        self._read_queue[stream_id] = []
+        self._read_ready[stream_id] = anyio.Event()
+        self._http.send_headers(
+            stream_id=stream_id,
+            headers=[
+                (b":method", b"CONNECT"),
+                (b":protocol", protocol),
+                (b":scheme", b"https"),
+                (b":authority", self._address[0].encode()),
+                (b":path", b"/chat"),
+            ],
+            end_stream=False,
+        )
+        await self._transmit()
+
+        status_code, _, _ = await self._receive_response(stream_id)
+        return status_code
+
+    async def send_stream_data(
+        self, stream_id: int, data: bytes = b"", *, end: bool = False
+    ) -> None:
+        """Put *data* on the stream, optionally ending our side of it."""
+        self._http.send_data(stream_id=stream_id, data=data, end_stream=end)
+        await self._transmit()
+
+    async def receive_stream_data(self, stream_id: int) -> tuple[bytes, bool]:
+        """Return the next DATA payload on the stream, and whether the stream ended."""
+        while True:
+            event = await self._wait_for_http_event(stream_id)
+            if isinstance(event, DataReceived):
+                return event.data, event.stream_ended
 
     async def reset(self, stream_id: int, error_code: int = 0) -> None:
         """Abandon a request with RESET_STREAM, as a cancelling client does."""
@@ -865,3 +929,151 @@ async def test_a_reset_stream_disconnects_the_app_and_is_not_written_to(
                 tg.cancel_scope.cancel()
     finally:
         await datagram_socket.aclose()
+
+
+def _websocket_echo(received: list[Any], disconnected: anyio.Event) -> Callable:
+    """Return a WebSocket app that echoes in upper case and records what it was given."""
+
+    async def _app(scope: Any, receive: Any, send: Any) -> None:  # noqa: ANN401
+        assert scope["type"] == "websocket"
+        received.append(dict(scope))
+        assert (await receive())["type"] == "websocket.connect"
+        await send({"type": "websocket.accept"})
+        while True:
+            message = await receive()
+            received.append(message)
+            if message["type"] == "websocket.receive":
+                await send({"type": "websocket.send", "text": message["text"].upper()})
+            else:
+                disconnected.set()
+                return
+
+    return _app
+
+
+async def _read_websocket_events(
+    transport: _H3Transport, websocket: wsproto.connection.Connection, stream_id: int
+) -> tuple[list[wsproto.events.Event], bool]:
+    """Read one DATA frame off the stream and decode the WebSocket events in it."""
+    data, stream_ended = await transport.receive_stream_data(stream_id)
+    websocket.receive_data(data)
+    return list(websocket.events()), stream_ended
+
+
+@pytest.mark.anyio
+async def test_h3_websocket_over_extended_connect(
+    tls_certs: TLSCerts, free_tcp_port: int, free_udp_port: int
+) -> None:
+    """A WebSocket really works over HTTP/3, frames and all - not just routing.
+
+    RFC 9220 carries RFC 8441's extended CONNECT over to HTTP/3, and aioquic offers
+    the setting that permits it. The unit tests pin which stream a CONNECT is routed
+    to; only a real client on a real QUIC connection says that the frames then flow,
+    and that the close at the end reaches both the peer and the app.
+    """
+    received: list[Any] = []
+    disconnected = anyio.Event()
+
+    async with (
+        _serving(tls_certs, free_tcp_port, free_udp_port, _websocket_echo(received, disconnected)),
+        _H3Transport.connect(HOST, free_udp_port, tls_certs) as transport,
+    ):
+        with anyio.fail_after(10):
+            stream_id, status = await transport.open_websocket(b"/chat?a=b")
+        assert status == 200  # noqa: PLR2004
+
+        websocket = wsproto.connection.Connection(wsproto.connection.ConnectionType.CLIENT)
+        await transport.send_stream_data(
+            stream_id, websocket.send(wsproto.events.TextMessage(data="hello"))
+        )
+        with anyio.fail_after(10):
+            events, _ = await _read_websocket_events(transport, websocket, stream_id)
+        assert events == [
+            wsproto.events.TextMessage(data="HELLO", frame_finished=True, message_finished=True)
+        ]
+
+        # The peer closing must end the server's side of the stream too, rather than
+        # leaving it half open - which over HTTP/1.1 the connection teardown hid
+        await transport.send_stream_data(
+            stream_id, websocket.send(wsproto.events.CloseConnection(code=1000))
+        )
+        with anyio.fail_after(10):
+            events, stream_ended = await _read_websocket_events(transport, websocket, stream_id)
+            assert events == [wsproto.events.CloseConnection(code=1000, reason="")]
+            while not stream_ended:
+                _, stream_ended = await transport.receive_stream_data(stream_id)
+            # And the app hears it, rather than waiting on receive() for ever
+            await disconnected.wait()
+
+    scope = received[0]
+    assert scope["http_version"] == "3"
+    assert scope["scheme"] == "wss"
+    assert scope["path"] == "/chat"
+    assert scope["query_string"] == b"a=b"
+    assert [message["type"] for message in received[1:]] == [
+        "websocket.receive",
+        "websocket.disconnect",
+    ]
+
+
+@pytest.mark.anyio
+async def test_h3_websocket_peer_ending_the_stream_disconnects_the_app(
+    tls_certs: TLSCerts, free_tcp_port: int, free_udp_port: int
+) -> None:
+    """END_STREAM from the peer is what a TCP close is over HTTP/1.1 (RFC 8441 s5.3).
+
+    It went unhandled, so the app was never told the peer had gone and the stream
+    never went idle - it stayed on the connection for as long as the connection did.
+    """
+    received: list[Any] = []
+    disconnected = anyio.Event()
+
+    async with (
+        _serving(tls_certs, free_tcp_port, free_udp_port, _websocket_echo(received, disconnected)),
+        _H3Transport.connect(HOST, free_udp_port, tls_certs) as transport,
+    ):
+        with anyio.fail_after(10):
+            stream_id, status = await transport.open_websocket(b"/chat")
+        assert status == 200  # noqa: PLR2004
+
+        await transport.send_stream_data(stream_id, end=True)
+
+        with anyio.fail_after(10):
+            await disconnected.wait()
+            # The server ends its side too, rather than leaving the stream half open
+            stream_ended = False
+            while not stream_ended:
+                _, stream_ended = await transport.receive_stream_data(stream_id)
+
+    assert [message["type"] for message in received[1:]] == ["websocket.disconnect"]
+
+
+@pytest.mark.anyio
+async def test_h3_extended_connect_for_another_protocol_is_not_implemented(
+    tls_certs: TLSCerts, free_tcp_port: int, free_udp_port: int
+) -> None:
+    """A :protocol this server does not tunnel is refused, on the wire.
+
+    The companion to test_a_connect_with_no_path_does_not_crash_the_server, which
+    covers a CONNECT carrying no :protocol at all.
+    """
+    seen: list[str] = []
+
+    async def _app(scope: Any, _receive: Any, send: Any) -> None:  # noqa: ANN401
+        assert scope["type"] == "http"
+        seen.append(scope["path"])
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    async with (
+        _serving(tls_certs, free_tcp_port, free_udp_port, _app),
+        _H3Transport.connect(HOST, free_udp_port, tls_certs) as transport,
+    ):
+        with anyio.fail_after(10):
+            assert await transport.connect_with_protocol(b"webtransport") == 501  # noqa: PLR2004
+        assert seen == [], "the app was handed a request it should never have seen"
+
+        # The connection is still usable, rather than having been taken down with it
+        with anyio.fail_after(10):
+            assert await transport.request_raw_path(b"/after") == 200  # noqa: PLR2004
+        assert seen == ["/after"]

--- a/tests/e2e/test_h3.py
+++ b/tests/e2e/test_h3.py
@@ -574,6 +574,9 @@ async def test_a_connect_with_no_path_does_not_crash_the_server(
     stream and read a :path that was never set, raising UnboundLocalError out of
     handle - and, with nothing catching it, out of UDPServer.run, taking the whole
     worker down. Driven here by a real client putting the CONNECT on the wire.
+
+    Carrying no :protocol, this is a request for a plain tunnel rather than the
+    extended CONNECT a WebSocket uses, so the answer is 501 (RFC 8441 s4).
     """
     seen: list[str] = []
 
@@ -600,7 +603,7 @@ async def test_a_connect_with_no_path_does_not_crash_the_server(
                 async with _H3Transport.connect(HOST, free_udp_port, tls_certs) as transport:
                     with anyio.fail_after(10):
                         status = await transport.connect_without_path()
-                    assert status == 400  # noqa: PLR2004
+                    assert status == 501  # noqa: PLR2004
                     assert seen == [], "the app was handed a request it should never have seen"
 
                     # The connection is still usable, rather than having been taken down

--- a/tests/protocol/test_h2.py
+++ b/tests/protocol/test_h2.py
@@ -8,11 +8,11 @@ import anyio
 import pytest
 from h2.config import H2Configuration
 from h2.connection import H2Connection
-from h2.events import ConnectionTerminated, PushedStreamReceived
+from h2.events import ConnectionTerminated, PushedStreamReceived, ResponseReceived
 
 from anycorn.app_wrappers import ASGIWrapper
 from anycorn.config import Config
-from anycorn.events import Closed, Event, RawData
+from anycorn.events import Closed, Event, RawData, Updated
 from anycorn.protocol.events import Trailers
 from anycorn.protocol.h2 import (
     BUFFER_HIGH_WATER,
@@ -20,6 +20,7 @@ from anycorn.protocol.h2 import (
     H2Protocol,
     StreamBuffer,
 )
+from anycorn.protocol.ws_stream import WSStream
 from anycorn.task_group import TaskGroup
 from anycorn.typing import ASGIReceiveCallable, ASGISendCallable, ConnectionState, Scope
 from anycorn.worker_context import EventWrapper, WorkerContext
@@ -202,6 +203,119 @@ async def test_connect_without_path_does_not_crash() -> None:
 
     # Must not raise, and no stream is handed to the app.
     await protocol.handle(RawData(data=client.data_to_send()))
+    assert protocol.streams == {}
+
+
+@pytest.mark.anyio
+async def test_extended_connect_for_websocket_opens_a_websocket_stream() -> None:
+    """The RFC 8441 handshake a browser sends is routed by its :protocol."""
+    protocol = H2Protocol(
+        Mock(),
+        Config(),
+        WorkerContext(None),
+        AsyncMock(),
+        ConnectionState({}),
+        None,
+        None,
+        AsyncMock(),
+        None,
+    )
+    client = H2Connection(config=H2Configuration(client_side=True))
+    client.initiate_connection()
+    client.send_headers(
+        1,
+        [
+            (b":method", b"CONNECT"),
+            (b":protocol", b"websocket"),
+            (b":scheme", b"https"),
+            (b":authority", b"anycorn"),
+            (b":path", b"/ws"),
+            (b"sec-websocket-version", b"13"),
+        ],
+    )
+
+    await protocol.handle(RawData(data=client.data_to_send()))
+
+    assert isinstance(protocol.streams[1], WSStream)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("connect_protocol", [None, b"webtransport"])
+async def test_connect_for_another_protocol_is_not_implemented(
+    connect_protocol: bytes | None,
+) -> None:
+    """Only :protocol websocket is tunnelled, and nothing else opens a stream.
+
+    Every CONNECT used to become a WebSocket stream, so a plain tunnel CONNECT - or
+    one naming another protocol - came back as the 400 of a malformed WebSocket
+    handshake. RFC 8441 s4 asks for 501 on a :protocol that is not supported.
+    """
+    sent: list[object] = []
+
+    async def send(event: object) -> None:
+        sent.append(event)
+
+    protocol = H2Protocol(
+        Mock(),
+        Config(),
+        WorkerContext(None),
+        AsyncMock(),
+        ConnectionState({}),
+        None,
+        None,
+        send,
+        None,
+    )
+    client = H2Connection(config=H2Configuration(client_side=True))
+    client.initiate_connection()
+    headers = [
+        (b":method", b"CONNECT"),
+        (b":scheme", b"https"),
+        (b":authority", b"anycorn"),
+        (b":path", b"/ws"),
+    ]
+    if connect_protocol is not None:
+        headers.insert(1, (b":protocol", connect_protocol))
+    client.send_headers(1, headers)
+
+    await protocol.handle(RawData(data=client.data_to_send()))
+
+    assert protocol.streams == {}
+    # Nor is the connection told it is busy over a request that never opened a stream
+    assert not any(isinstance(event, Updated) for event in sent)
+    events = []
+    for event in sent:
+        if isinstance(event, RawData):
+            events.extend(client.receive_data(event.data))
+    responses = [event for event in events if isinstance(event, ResponseReceived)]
+    assert dict(responses[0].headers)[b":status"] == b"501"
+
+
+@pytest.mark.anyio
+async def test_h2c_upgrade_from_a_connect_does_not_crash() -> None:
+    """An h2c upgrade carries the HTTP/1.1 method, so it can be a CONNECT.
+
+    Nothing is served for one, so initiate has no stream to hand the end of the body
+    to - reading self.streams for it would be a KeyError, out of the connection's
+    very first call.
+    """
+    protocol = H2Protocol(
+        Mock(),
+        Config(),
+        WorkerContext(None),
+        Mock(),  # spawn() for the send task is a plain call, not a coroutine
+        ConnectionState({}),
+        None,
+        None,
+        AsyncMock(),
+        None,
+    )
+
+    await protocol.initiate(
+        [(b":method", b"CONNECT"), (b":path", b"anycorn:443"), (b":authority", b"anycorn")],
+        "AAMAAABkAAQAoAAAAAIAAAAA",
+    )
+
     assert protocol.streams == {}
 
 

--- a/tests/protocol/test_h3.py
+++ b/tests/protocol/test_h3.py
@@ -6,11 +6,13 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aioquic.h3.events import HeadersReceived
 from aioquic.quic.events import QuicEvent, StopSendingReceived, StreamReset
 
 from anycorn.config import Config
 from anycorn.protocol.events import Body, EndBody, Event, Response, StreamClosed
 from anycorn.protocol.h3 import H3Protocol
+from anycorn.protocol.ws_stream import WSStream
 from anycorn.typing import ConnectionState, TLSExtension
 from anycorn.worker_context import WorkerContext
 
@@ -212,3 +214,73 @@ async def test_closing_a_reset_stream_stops_it_being_remembered() -> None:
     await protocol.stream_send(Body(stream_id=1, data=b"reused"))
 
     assert connection.attempted == [("data", 1)]
+
+
+class _HeaderRecordingH3Connection(_RecordingH3Connection):
+    """Keeps the headers of every response, which the routing tests assert on."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.responses: list[list[tuple[bytes, bytes]]] = []
+
+    def send_headers(
+        self,
+        stream_id: int,
+        headers: list[tuple[bytes, bytes]],
+        end_stream: bool = False,  # noqa: FBT001, FBT002
+    ) -> None:
+        self.responses.append(headers)
+        super().send_headers(stream_id, headers, end_stream)
+
+
+def _connect_headers(protocol_header: bytes | None) -> list[tuple[bytes, bytes]]:
+    headers = [
+        (b":method", b"CONNECT"),
+        (b":scheme", b"https"),
+        (b":authority", b"anycorn"),
+        (b":path", b"/ws"),
+        (b"sec-websocket-version", b"13"),
+    ]
+    if protocol_header is not None:
+        headers.insert(1, (b":protocol", protocol_header))
+    return headers
+
+
+@pytest.mark.anyio
+async def test_extended_connect_for_websocket_opens_a_websocket_stream() -> None:
+    """RFC 9220 carries RFC 8441's extended CONNECT over to HTTP/3."""
+    protocol = _make_protocol()
+    protocol.task_group = AsyncMock()
+    connection = _HeaderRecordingH3Connection()
+    protocol.connection = connection
+
+    await protocol._create_stream(
+        HeadersReceived(stream_id=0, stream_ended=False, headers=_connect_headers(b"websocket"))
+    )
+
+    assert isinstance(protocol.streams[0], WSStream)
+    assert connection.responses == []  # nothing refused; the app answers the handshake
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("protocol_header", [None, b"webtransport"])
+async def test_connect_for_another_protocol_is_not_implemented(
+    protocol_header: bytes | None,
+) -> None:
+    """Only :protocol websocket is tunnelled, and nothing else opens a stream.
+
+    aioquic requires no more than :method and :authority, so unlike h2 it hands a
+    plain tunnel CONNECT straight to the server - which used to serve every CONNECT
+    as a WebSocket. RFC 8441 s4 asks for 501 on a :protocol that is not supported.
+    """
+    protocol = _make_protocol()
+    protocol.task_group = AsyncMock()
+    connection = _HeaderRecordingH3Connection()
+    protocol.connection = connection
+
+    await protocol._create_stream(
+        HeadersReceived(stream_id=0, stream_ended=False, headers=_connect_headers(protocol_header))
+    )
+
+    assert protocol.streams == {}
+    assert dict(connection.responses[0])[b":status"] == b"501"

--- a/tests/protocol/test_h3.py
+++ b/tests/protocol/test_h3.py
@@ -42,16 +42,6 @@ def _make_protocol() -> H3Protocol:
 
 
 @pytest.mark.anyio
-async def test_stream_send_stream_closed_removes_stream() -> None:
-    protocol = _make_protocol()
-    protocol.streams = {1: object(), 2: object()}  # type: ignore[dict-item]
-
-    await protocol.stream_send(StreamClosed(stream_id=1))
-
-    assert protocol.streams == {2: protocol.streams[2]}
-
-
-@pytest.mark.anyio
 async def test_stream_send_stream_closed_is_idempotent() -> None:
     protocol = _make_protocol()
 
@@ -118,6 +108,25 @@ class _RecordingH3Connection:
         end_stream: bool,  # noqa: ARG002, FBT001
     ) -> None:
         self._write("data", stream_id)
+
+
+@pytest.mark.anyio
+async def test_stream_send_stream_closed_removes_stream() -> None:
+    """The stream is dropped, and told, so the app hears the disconnect.
+
+    Popping it and no more left a WebSocket that closed itself - which is how every
+    WebSocket ends - with an app still waiting on receive() for ever. h2 hands the
+    event back the same way, as does _reset_stream here.
+    """
+    protocol = _make_protocol()
+    closing, other = _RecordingStream(), _RecordingStream()
+    protocol.streams = {1: closing, 2: other}  # type: ignore[dict-item]
+
+    await protocol.stream_send(StreamClosed(stream_id=1))
+
+    assert protocol.streams == {2: other}
+    assert closing.events == [StreamClosed(stream_id=1)]
+    assert other.events == []
 
 
 @pytest.mark.anyio

--- a/tests/protocol/test_ws_stream.py
+++ b/tests/protocol/test_ws_stream.py
@@ -363,6 +363,65 @@ async def test_handle_connection(stream: WSStream) -> None:
 
 
 @pytest.mark.anyio
+async def test_peer_ending_the_stream_closes_the_connected_websocket(
+    stream: WSStream,
+) -> None:
+    """END_STREAM is what a TCP close is over HTTP/1.1 - the WebSocket is over.
+
+    RFC 8441 s5.3. Only h2 and h3 deliver this to a WebSocket; h11 swaps in a
+    pass-through connection the moment it sees the upgrade. It went unhandled, so
+    the app never heard the disconnect and the stream never went idle - the
+    connection could not be reclaimed either.
+    """
+    await stream.handle(
+        Request(
+            stream_id=1,
+            http_version="2",
+            headers=[(b"sec-websocket-version", b"13")],
+            raw_path=b"/",
+            method="CONNECT",
+            state=ConnectionState({}),
+        )
+    )
+    await stream.app_send(cast("WebsocketAcceptEvent", {"type": "websocket.accept"}))
+    stream.send.reset_mock()  # type: ignore[attr-defined]
+
+    await stream.handle(EndBody(stream_id=1))
+
+    assert stream.state == ASGIWebsocketState.CLOSED
+    assert stream.idle
+    # Our side is ended too, rather than left half open
+    assert stream.send.call_args_list == [  # type: ignore[attr-defined]
+        call(EndData(stream_id=1)),
+        call(StreamClosed(stream_id=1)),
+    ]
+
+
+@pytest.mark.anyio
+async def test_peer_ending_the_stream_during_the_handshake_is_refused(
+    stream: WSStream,
+) -> None:
+    """Nothing left to accept onto, so the handshake is answered rather than left open."""
+    await stream.handle(
+        Request(
+            stream_id=1,
+            http_version="2",
+            headers=[(b"sec-websocket-version", b"13")],
+            raw_path=b"/",
+            method="CONNECT",
+            state=ConnectionState({}),
+        )
+    )
+    stream.send.reset_mock()  # type: ignore[attr-defined]
+
+    await stream.handle(EndBody(stream_id=1))
+
+    sent = [call_[0][0] for call_ in stream.send.call_args_list]  # type: ignore[attr-defined]
+    assert sent[0].status_code == HTTPStatus.BAD_REQUEST
+    assert sent[-1] == StreamClosed(stream_id=1)
+
+
+@pytest.mark.anyio
 async def test_handle_closed(stream: WSStream) -> None:
     await stream.handle(StreamClosed(stream_id=1))
     stream.app_put.assert_called()  # type: ignore[attr-defined]
@@ -398,6 +457,36 @@ async def test_handle_client_close_reports_its_code(stream: WSStream) -> None:
     await stream.handle(StreamClosed(stream_id=1))
 
     assert stream.app_put.call_args_list == [call({"type": "websocket.disconnect", "code": 1000})]
+
+
+@pytest.mark.anyio
+async def test_client_close_ends_the_stream(stream: WSStream) -> None:
+    """The peer closing must end our side too, as an app-initiated close does.
+
+    Over HTTP/1.1 the connection is torn down regardless and EndData is ignored, but
+    over HTTP/2 and HTTP/3 the stream was left half open - the peer never saw it end,
+    and its send buffer and place in the priority tree outlived it.
+    """
+    await stream.handle(
+        Request(
+            stream_id=1,
+            http_version="2",
+            headers=[(b"sec-websocket-version", b"13")],
+            raw_path=b"/",
+            method="CONNECT",
+            state=ConnectionState({}),
+        )
+    )
+    await stream.app_send(cast("WebsocketAcceptEvent", {"type": "websocket.accept"}))
+    stream.send.reset_mock()  # type: ignore[attr-defined]
+
+    # A masked client close frame carrying code 1000
+    await stream.handle(Data(stream_id=1, data=b"\x88\x82\x00\x00\x00\x00\x03\xe8"))
+
+    sent = [call_[0][0] for call_ in stream.send.call_args_list]  # type: ignore[attr-defined]
+    assert isinstance(sent[0], Data)  # our close frame in reply
+    assert sent[1:] == [EndData(stream_id=1), StreamClosed(stream_id=1)]
+    assert stream.idle
 
 
 @pytest.mark.anyio

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -12,6 +12,7 @@ import anyio
 import h2.config
 import h2.connection
 import h2.events
+import h2.settings
 import h11
 import pytest
 import wsproto
@@ -25,7 +26,9 @@ from .helpers import SANITY_BODY, sanity_framework, serve_in_memory
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from anycorn.typing import HTTPScope, Scope
+    from anycorn.typing import HTTPScope, Scope, WebsocketScope
+
+    from .helpers import MemoryClientStream
 
 
 @pytest.mark.anyio
@@ -161,6 +164,7 @@ async def test_http2_websocket() -> None:
             stream_id,
             [
                 (":method", "CONNECT"),
+                (":protocol", "websocket"),
                 (":path", "/"),
                 (":authority", "anycorn"),
                 (":scheme", "https"),
@@ -327,6 +331,7 @@ async def test_http2_websocket_rejects_a_target_with_no_asgi_path(target: bytes)
             stream_id,
             [
                 (b":method", b"CONNECT"),
+                (b":protocol", b"websocket"),
                 (b":path", target),
                 (b":authority", b"anycorn"),
                 (b":scheme", b"https"),
@@ -425,3 +430,174 @@ async def test_http1_websocket_frame_arriving_with_the_handshake() -> None:
 
     assert isinstance(events[0], wsproto.events.AcceptConnection)
     assert events[-1] == wsproto.events.TextMessage(data="Hello & Goodbye")
+
+
+async def _h2_connect(
+    client_stream: MemoryClientStream,
+    h2_client: h2.connection.H2Connection,
+    headers: list[tuple[bytes, bytes]],
+) -> int:
+    """Open a stream carrying *headers* and return its id."""
+    stream_id = h2_client.get_next_available_stream_id()
+    h2_client.send_headers(stream_id, headers)
+    await client_stream.send_all(h2_client.data_to_send())
+    return stream_id
+
+
+async def _read_h2_response(
+    client_stream: MemoryClientStream, h2_client: h2.connection.H2Connection
+) -> dict[bytes, bytes]:
+    """Read until the server answers, and return the response headers it answered with."""
+    with anyio.fail_after(5):
+        while True:
+            data = await client_stream.receive_some(4096)
+            if data == b"":
+                msg = "the connection closed before the server answered"
+                raise AssertionError(msg)
+            for event in h2_client.receive_data(data):
+                if isinstance(event, h2.events.ResponseReceived):
+                    return dict(event.headers)
+            await client_stream.send_all(h2_client.data_to_send())
+
+
+WEBSOCKET_CONNECT_HEADERS = [
+    (b":method", b"CONNECT"),
+    (b":protocol", b"websocket"),
+    (b":path", b"/"),
+    (b":authority", b"anycorn"),
+    (b":scheme", b"https"),
+    (b"sec-websocket-version", b"13"),
+]
+
+
+@pytest.mark.anyio
+async def test_http2_advertises_the_extended_connect_setting() -> None:
+    """The opening SETTINGS carries SETTINGS_ENABLE_CONNECT_PROTOCOL.
+
+    That setting is the whole of what a browser waits for: without it Chrome and
+    Firefox will not send the extended CONNECT of RFC 8441, and there is no HTTP/1.1
+    Upgrade to fall back to on a connection that is already HTTP/2.
+    """
+    async with serve_in_memory(sanity_framework, alpn_protocol="h2") as client_stream:
+        h2_client = h2.connection.H2Connection()
+        h2_client.initiate_connection()
+        await client_stream.send_all(h2_client.data_to_send())
+
+        settings = None
+        with anyio.fail_after(5):
+            while settings is None:
+                for event in h2_client.receive_data(await client_stream.receive_some(4096)):
+                    if isinstance(event, h2.events.RemoteSettingsChanged):
+                        settings = event.changed_settings
+
+        enabled = settings[h2.settings.SettingCodes.ENABLE_CONNECT_PROTOCOL]
+        assert enabled.new_value == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("protocol", [None, b"webtransport"])
+async def test_http2_connect_for_another_protocol_is_not_implemented(
+    protocol: bytes | None,
+) -> None:
+    """WebSockets are the only protocol tunnelled; anything else is answered 501.
+
+    Every CONNECT used to be handed to a WebSocket stream, so a request for a plain
+    tunnel - or for another protocol over extended CONNECT - came back as the 400 of
+    a malformed WebSocket handshake. This server is not a forward proxy, and RFC 8441
+    s4 asks for 501 on a :protocol it does not support.
+    """
+    seen: list[str] = []
+    async with serve_in_memory(_recording_app(seen), alpn_protocol="h2") as client_stream:
+        h2_client = h2.connection.H2Connection()
+        h2_client.initiate_connection()
+        await client_stream.send_all(h2_client.data_to_send())
+        headers = [
+            (b":method", b"CONNECT"),
+            (b":path", b"/"),
+            (b":authority", b"anycorn"),
+            (b":scheme", b"https"),
+        ]
+        if protocol is not None:
+            headers.insert(1, (b":protocol", protocol))
+        await _h2_connect(client_stream, h2_client, headers)
+
+        response = await _read_h2_response(client_stream, h2_client)
+
+    assert response[b":status"] == b"501"
+    assert seen == []
+
+
+@pytest.mark.anyio
+async def test_http2_websocket_negotiates_a_subprotocol() -> None:
+    """Subprotocol negotiation rides on the extended CONNECT as it does on an upgrade."""
+    subprotocols = []
+
+    async def _app(scope: Scope, receive: Callable, send: Callable) -> None:
+        subprotocols.extend(cast("WebsocketScope", scope)["subprotocols"])
+        await receive()
+        await send({"type": "websocket.accept", "subprotocol": "superchat"})
+        await receive()
+
+    async with serve_in_memory(_app, alpn_protocol="h2") as client_stream:
+        h2_client = h2.connection.H2Connection()
+        h2_client.initiate_connection()
+        await client_stream.send_all(h2_client.data_to_send())
+        await _h2_connect(
+            client_stream,
+            h2_client,
+            [*WEBSOCKET_CONNECT_HEADERS, (b"sec-websocket-protocol", b"chat, superchat")],
+        )
+
+        response = await _read_h2_response(client_stream, h2_client)
+
+    assert subprotocols == ["chat", "superchat"]
+    assert response[b":status"] == b"200"
+    assert response[b"sec-websocket-protocol"] == b"superchat"
+    # RFC 8441 s5.1: the HTTP/1.1 handshake headers have no place over HTTP/2
+    assert b"sec-websocket-accept" not in response
+    assert b"upgrade" not in response
+
+
+@pytest.mark.anyio
+async def test_http2_websocket_peer_ending_the_stream_disconnects_the_app() -> None:
+    """END_STREAM from the peer is what a TCP close is over HTTP/1.1 (RFC 8441 s5.3).
+
+    It went unhandled, so the app was never told the peer had gone, and the stream
+    stayed on the connection for as long as the connection lived - never idle, so
+    never reclaimed either.
+    """
+    received: list[str] = []
+    disconnected = anyio.Event()
+
+    async def _app(_scope: Scope, receive: Callable, send: Callable) -> None:
+        await receive()
+        await send({"type": "websocket.accept"})
+        while True:
+            message = await receive()
+            received.append(message["type"])
+            if message["type"] == "websocket.disconnect":
+                disconnected.set()
+                return
+
+    async with serve_in_memory(_app, alpn_protocol="h2") as client_stream:
+        h2_client = h2.connection.H2Connection()
+        h2_client.initiate_connection()
+        await client_stream.send_all(h2_client.data_to_send())
+        stream_id = await _h2_connect(client_stream, h2_client, WEBSOCKET_CONNECT_HEADERS)
+        assert (await _read_h2_response(client_stream, h2_client))[b":status"] == b"200"
+
+        h2_client.end_stream(stream_id)
+        await client_stream.send_all(h2_client.data_to_send())
+
+        with anyio.fail_after(5):
+            await disconnected.wait()
+
+        # The server ends its side too, rather than leaving the stream half open
+        ended = False
+        with anyio.fail_after(5):
+            while not ended:
+                for event in h2_client.receive_data(await client_stream.receive_some(4096)):
+                    if isinstance(event, h2.events.StreamEnded):
+                        ended = True
+
+    assert received == ["websocket.disconnect"]


### PR DESCRIPTION
WebSockets over HTTP/2 and HTTP/3 use the extended CONNECT of [RFC 8441](https://www.rfc-editor.org/rfc/rfc8441), which [RFC 9220](https://www.rfc-editor.org/rfc/rfc9220) carries over to HTTP/3. It is what Chrome and Firefox use for every WebSocket they open on an HTTP/2 connection; Safari still upgrades over HTTP/1.1. Prompted by https://github.com/mattermost/mattermost/issues/30285, which is what it looks like when a server does not implement it — Safari connects, Chrome and Firefox fail with a 1006.

anycorn already handled the handshake itself: it advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`, and a browser's CONNECT is accepted with a 200 and frames flow. That failure mode is not present here. But nothing was testing it, and three things around it were wrong.

## A CONNECT was routed by its method alone

Every CONNECT became a WebSocket stream, whatever it asked for. A plain tunnel CONNECT — or an extended CONNECT naming some other protocol — was answered with the 400 of a malformed WebSocket handshake, from a server that is not a forward proxy at all. Only `:protocol: websocket` opens a WebSocket now; anything else gets `501 Not Implemented`, which is what RFC 8441 §4 and RFC 9113 §8.5 ask for.

This matters most over HTTP/3. h2 requires `:path` and `:scheme` on every request and so rejects a classic tunnel CONNECT before it arrives, but aioquic requires no more than `:method` and `:authority` and hands one straight to the server.

`_create_stream` now reports whether it created a stream, so a refused CONNECT no longer marks the connection busy with an `Updated(idle=False)` that nothing ever clears. Two callers index `self.streams` right after it and would have hit a `KeyError` on a stream that was never made: `initiate()`, since an h2c upgrade carries whatever method the HTTP/1.1 request used and can therefore be a CONNECT, and the server-push path.

## The peer ending its side of the stream went unhandled

RFC 8441 §5.3 makes END_STREAM the equivalent of a TCP close. It was ignored, so the app was never told the peer had gone, and the stream never went idle — the connection could not be reclaimed either. `WSStream` now ends its own side and closes.

h11 is unaffected: it swaps in a pass-through connection the moment it sees the upgrade, so a WebSocket there is never sent an `EndBody`.

## A peer-initiated close left the stream half open

`websocket.close` from the app sent `EndData`; a close frame from the peer did not. Over HTTP/1.1 the connection is torn down regardless and this is invisible, but over HTTP/2 and HTTP/3 the peer never saw the stream end, and its send buffer and its place in the priority tree outlived it for the life of the connection.

## `H3Protocol.stream_send` dropped `StreamClosed` on the floor

It popped the stream and no more, so a stream that closed *itself* was never told it had closed. Harmless for an HTTP request, where the app has already finished — but a WebSocket always ends by closing itself, whether the peer sent a close frame or the app did, and the app was left waiting on `receive()` forever with no `websocket.disconnect` ever arriving. h2 hands the event back in `_close_stream`, and so does `_reset_stream` here; this path was the one out of step.

Found by the new HTTP/3 end-to-end test, which is the point of writing them.

## Tests

963 of the 1060 added lines. Coverage of WebSockets over HTTP/2 was two sanity tests, and over HTTP/3 there was none at all.

- **`tests/e2e/test_h2_websocket.py`** (new) — a real `worker_serve` over a real TCP socket with a trustme certificate, ALPN-negotiated to h2, driving a raw `h2` client through the whole browser handshake: SETTINGS, extended CONNECT, wsproto frames in DATA both ways, close, stream end. Plus scope assertions (`wss`, `http_version` `2`, none of the HTTP/1.1 handshake headers) and the 501 refusal with the connection still usable afterwards. This is what caught the half-open stream, as a hang waiting for `StreamEnded`.
- **`tests/e2e/test_h3.py`** — the same over a real QUIC connection: frames both ways, the close reaching both peer and app, the peer ending its side disconnecting the app, and a 501 for a `:protocol` this server does not tunnel.
- **`tests/test_sanity.py`** — end to end through `TCPServer`: the `ENABLE_CONNECT_PROTOCOL` setting a browser waits for, subprotocol negotiation, the 501, and the half-close.
- Unit tests in `tests/protocol/test_h2.py`, `test_h3.py` and `test_ws_stream.py`, including the h2c-upgrade-from-a-CONNECT case.

Each regression test was confirmed to fail against the unfixed code.

Two existing tests changed expectation from 400 to 501 for a CONNECT carrying no `:protocol`, and `test_stream_send_stream_closed_removes_stream` was using a bare `object()` as a stand-in stream, so it asserted nothing about the stream being told; it now uses `_RecordingStream`. The existing HTTP/2 WebSocket sanity tests send `:protocol: websocket`, as a browser does.

## Behaviour changes

- A CONNECT that is not `:protocol: websocket` is answered `501` rather than `400`.
- A WebSocket over HTTP/2 or HTTP/3 now sees its stream ended when it closes, and the app now receives `websocket.disconnect` when the peer ends the stream or closes the socket — over HTTP/3 that message was previously never delivered at all.

No change to HTTP/1.1 WebSockets, and no configuration to set: the setting that permits extended CONNECT was already advertised.
